### PR TITLE
Add more SpeedUHC stats

### DIFF
--- a/packages/schemas/src/player/gamemodes/speeduhc/index.ts
+++ b/packages/schemas/src/player/gamemodes/speeduhc/index.ts
@@ -19,7 +19,7 @@ export class SpeedUHC {
   @Field()
   public score: number;
 
-  @Field({ default: 'None' })
+  @Field({ default: 'none' })
   public activeMastery: string;
 
   @Field({ getter: (target: SpeedUHC) => getLevelIndex(target.score) + 1 })

--- a/packages/schemas/src/player/gamemodes/speeduhc/index.ts
+++ b/packages/schemas/src/player/gamemodes/speeduhc/index.ts
@@ -19,6 +19,9 @@ export class SpeedUHC {
   @Field()
   public score: number;
 
+  @Field({ default: 'None' })
+  public activeMastery: string;
+
   @Field({ getter: (target: SpeedUHC) => getLevelIndex(target.score) + 1 })
   public level: number;
 
@@ -28,6 +31,7 @@ export class SpeedUHC {
   public constructor(data: APIData) {
     this.coins = data.coins;
     this.score = data.score;
+    this.activeMastery = data.activeMasterPerk;
 
     this.overall = new SpeedUHCMode(data, '');
     this.solo = new SpeedUHCMode(data, 'solo');

--- a/packages/schemas/src/player/gamemodes/speeduhc/mode.ts
+++ b/packages/schemas/src/player/gamemodes/speeduhc/mode.ts
@@ -21,6 +21,9 @@ export class SpeedUHCMode {
   @Field()
   public kdr: number;
 
+  @Field()
+  public assists: number;
+
   public constructor(data: APIData, mode: string) {
     mode = mode ? `_${mode}` : mode;
 
@@ -28,6 +31,7 @@ export class SpeedUHCMode {
     this.losses = data[`losses${mode}`];
     this.kills = data[`kills${mode}`];
     this.deaths = data[`deaths${mode}`];
+    this.assists = data[`assists${mode}`];
 
     this.wlr = ratio(this.wins, this.losses);
     this.kdr = ratio(this.kills, this.deaths);


### PR DESCRIPTION
Added the assists stat to speed uhc, could be used later for Kills+Assists/Deaths ratio but for now is just a nice to have. Also added active mastery since it allows people to see what others are using.