### PR TITLE
Add megawalls kit stats

### DIFF
--- a/packages/schemas/src/player/gamemodes/megawalls/index.ts
+++ b/packages/schemas/src/player/gamemodes/megawalls/index.ts
@@ -1,6 +1,7 @@
 import { ratio } from '@statsify/math';
 import { APIData } from '@statsify/util';
 import { Field } from '../../../decorators';
+import { MegaWallsKit } from './kit';
 
 export class MegaWalls {
   @Field()
@@ -54,6 +55,78 @@ export class MegaWalls {
   @Field()
   public witherKills: number;
 
+  @Field({ required: false })
+  public herobrine?: MegaWallsKit;
+
+  @Field({ required: false })
+  public skeleton?: MegaWallsKit;
+
+  @Field({ required: false })
+  public zombie?: MegaWallsKit;
+
+  @Field({ required: false })
+  public creeper?: MegaWallsKit;
+
+  @Field({ required: false })
+  public enderman?: MegaWallsKit;
+
+  @Field({ required: false })
+  public spider?: MegaWallsKit;
+
+  @Field({ required: false })
+  public squid?: MegaWallsKit;
+
+  @Field({ required: false })
+  public dreadlord?: MegaWallsKit;
+
+  @Field({ required: false })
+  public shaman?: MegaWallsKit;
+
+  @Field({ required: false })
+  public arcanist?: MegaWallsKit;
+
+  @Field({ required: false })
+  public golem?: MegaWallsKit;
+
+  @Field({ required: false })
+  public pigman?: MegaWallsKit;
+
+  @Field({ required: false })
+  public blaze?: MegaWallsKit;
+
+  @Field({ required: false })
+  public pirate?: MegaWallsKit;
+
+  @Field({ required: false })
+  public hunter?: MegaWallsKit;
+
+  @Field({ required: false })
+  public phoenix?: MegaWallsKit;
+
+  @Field({ required: false })
+  public werewolf?: MegaWallsKit;
+
+  @Field({ required: false })
+  public moleman?: MegaWallsKit;
+
+  @Field({ required: false })
+  public cow?: MegaWallsKit;
+
+  @Field({ required: false })
+  public shark?: MegaWallsKit;
+
+  @Field({ required: false })
+  public assassin?: MegaWallsKit;
+
+  @Field({ required: false })
+  public renegade?: MegaWallsKit;
+
+  @Field({ required: false })
+  public automaton?: MegaWallsKit;
+
+  @Field({ required: false })
+  public snowman?: MegaWallsKit;
+
   public constructor(data: APIData) {
     this.coins = data.coins;
     this.class = data.chosen_class ?? 'none';
@@ -72,5 +145,30 @@ export class MegaWalls {
     this.fkdr = ratio(this.finalKills, this.finalDeaths);
     this.witherDamage = data.wither_damage;
     this.witherKills = data.wither_kills;
+
+    this.herobrine = new MegaWallsKit(data, 'herobrine');
+    this.skeleton = new MegaWallsKit(data, 'skeleton');
+    this.zombie = new MegaWallsKit(data, 'zombie');
+    this.creeper = new MegaWallsKit(data, 'creeper');
+    this.enderman = new MegaWallsKit(data, 'enderman');
+    this.spider = new MegaWallsKit(data, 'spider');
+    this.squid = new MegaWallsKit(data, 'squid');
+    this.dreadlord = new MegaWallsKit(data, 'dreadlord');
+    this.shaman = new MegaWallsKit(data, 'shaman');
+    this.arcanist = new MegaWallsKit(data, 'arcanist');
+    this.golem = new MegaWallsKit(data, 'golem');
+    this.pigman = new MegaWallsKit(data, 'pigman');
+    this.blaze = new MegaWallsKit(data, 'blaze');
+    this.pirate = new MegaWallsKit(data, 'pirate');
+    this.hunter = new MegaWallsKit(data, 'hunter');
+    this.phoenix = new MegaWallsKit(data, 'phoenix');
+    this.werewolf = new MegaWallsKit(data, 'werewolf');
+    this.moleman = new MegaWallsKit(data, 'moleman');
+    this.cow = new MegaWallsKit(data, 'cow');
+    this.shark = new MegaWallsKit(data, 'shark');
+    this.assassin = new MegaWallsKit(data, 'assassin');
+    this.renegade = new MegaWallsKit(data, 'renegade');
+    this.automaton = new MegaWallsKit(data, 'automaton');
+    this.snowman = new MegaWallsKit(data, 'snowman');
   }
 }

--- a/packages/schemas/src/player/gamemodes/megawalls/kit.ts
+++ b/packages/schemas/src/player/gamemodes/megawalls/kit.ts
@@ -1,0 +1,65 @@
+import { ratio } from '@statsify/math';
+import { APIData } from '@statsify/util';
+import { Field } from '../../../decorators';
+
+export class MegaWallsKit {
+  @Field()
+  public wins: number;
+
+  @Field()
+  public losses: number;
+
+  @Field()
+  public wlr: number;
+
+  @Field()
+  public kills: number;
+
+  @Field()
+  public deaths: number;
+
+  @Field()
+  public kdr: number;
+
+  @Field()
+  public finalKills: number;
+
+  @Field()
+  public finalDeaths: number;
+
+  @Field()
+  public fkdr: number;
+
+  @Field({ leaderboard: false })
+  public assists: number;
+
+  @Field({ leaderboard: false })
+  public timePlayed: number;
+
+  @Field({ leaderboard: false })
+  public witherDamage: number;
+
+  @Field({ leaderboard: false })
+  public witherKills: number;
+
+  public constructor(data: APIData, kit: string) {
+    kit = kit ? `${kit}_` : kit;
+
+    this.wins = data[`${kit}wins`];
+    this.losses = data[`${kit}losses`];
+    this.wlr = ratio(this.wins, this.losses);
+
+    this.kills = data[`${kit}kills`];
+    this.deaths = data[`${kit}deaths`];
+    this.kdr = ratio(this.kills, this.deaths);
+
+    this.finalKills = data[`${kit}final_kills`];
+    this.finalDeaths = data[`${kit}final_deaths`];
+    this.fkdr = ratio(this.finalKills, this.finalDeaths);
+
+    this.assists = data[`${kit}assists`];
+    this.timePlayed = data[`${kit}time_played`];
+    this.witherDamage = data[`${kit}wither_damage`];
+    this.witherKills = data[`${kit}wither_kills`];
+  }
+}

--- a/packages/schemas/src/player/gamemodes/skywars/index.ts
+++ b/packages/schemas/src/player/gamemodes/skywars/index.ts
@@ -84,10 +84,7 @@ export class SkyWars {
       data.skywars_golden_boxes
     );
 
-    this.star = (data.levelFormatted || '⋆').replace(
-      /1|2|3|4|5|6|7|8|9|0|a|b|c|d|e|f|k|r|l|§/g,
-      ''
-    );
+    this.star = (data.levelFormatted || '⋆').replace(/[0-9]|[a-f]|k|r|l|§/g, '');
 
     const normalKit = parseKit(data.activeKit_SOLO_random ? 'random' : data.activeKit_SOLO);
     const insaneKit = parseKit(data.activeKit_TEAMS_random ? 'random' : data.activeKit_TEAMS);


### PR DESCRIPTION
This pull request aims to overhaul mega walls stats to include kits and have the capability for kits leaderboards. However some discussion is needed before I mark this as ready to merge.

There is an issue of I am not sure how to structure the class with the kits, there can be a class with the overall stats separate from the rest of the kits with the total stats. Or it can be kept as is with only adding the kits to the `MegaWalls` class. I will await review before marking as ready to merge as I do think this needs some discussion.