### PR TITLE
feat(redoc): add tags to each endpoint

### DIFF
--- a/apps/api/src/guild/guild.controller.ts
+++ b/apps/api/src/guild/guild.controller.ts
@@ -9,7 +9,7 @@ import { GuildService } from './guild.service';
 export class GuildController {
   public constructor(private readonly guildService: GuildService) {}
 
-  @ApiOperation({ summary: 'Get a Guild' })
+  @ApiOperation({ summary: 'Get a Guild', tags: ['Guild'] })
   @ApiOkResponse({ type: GetGuildResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Get()

--- a/apps/api/src/guild/leaderboards/guild-leaderboard.controller.ts
+++ b/apps/api/src/guild/leaderboards/guild-leaderboard.controller.ts
@@ -15,7 +15,7 @@ export class GuildLeaderboardController {
   public constructor(private readonly guildLeaderboardService: GuildLeaderboardService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Get a Guild Leaderboard' })
+  @ApiOperation({ summary: 'Get a Guild Leaderboard', tags: ['Guild Leaderboards'] })
   @ApiOkResponse({ type: PostGuildLeaderboardResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Auth({ weight: 10 })
@@ -39,7 +39,7 @@ export class GuildLeaderboardController {
   }
 
   @Post('/rankings')
-  @ApiOperation({ summary: 'Get a Guild Ranking' })
+  @ApiOperation({ summary: 'Get a Guild Ranking', tags: ['Guild Leaderboards'] })
   @ApiOkResponse({ type: PostGuildRankingsResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Auth({ weight: 3 })

--- a/apps/api/src/historical/historical.controller.ts
+++ b/apps/api/src/historical/historical.controller.ts
@@ -11,7 +11,7 @@ import { HistoricalService } from './historical.service';
 export class HistoricalController {
   public constructor(private readonly historicalService: HistoricalService) {}
 
-  @ApiOperation({ summary: 'Get the Historical stats of a Player' })
+  @ApiOperation({ summary: 'Get the Historical stats of a Player', tags: ['Historical'] })
   @ApiOkResponse({ type: GetHistoricalResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Get()
@@ -34,7 +34,7 @@ export class HistoricalController {
     };
   }
 
-  @ApiOperation({ summary: 'Reset the Historical stats of a Player' })
+  @ApiOperation({ summary: 'Reset the Historical stats of a Player', tags: ['Historical'] })
   @ApiOkResponse({ type: GetPlayerResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Delete()

--- a/apps/api/src/hypixel-resources/hypixel-resources.controller.ts
+++ b/apps/api/src/hypixel-resources/hypixel-resources.controller.ts
@@ -9,7 +9,7 @@ export class HypixelResourcesController {
   public constructor(private readonly hypixelService: HypixelService) {}
 
   @Get(`/watchdog`)
-  @ApiOperation({ summary: 'Get Watchdog Stats' })
+  @ApiOperation({ summary: 'Get Watchdog Stats', tags: ['Hypixel Resources'] })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @ApiOkResponse({ type: GetWatchdogResponse })
   @Auth()
@@ -23,7 +23,7 @@ export class HypixelResourcesController {
   }
 
   @Get(`/gamecounts`)
-  @ApiOperation({ summary: 'Get Hypixel Gamecounts' })
+  @ApiOperation({ summary: 'Get Hypixel Gamecounts', tags: ['Hypixel Resources'] })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @ApiOkResponse({ type: GetGamecountsResponse })
   @Auth()

--- a/apps/api/src/player/leaderboards/player-leaderboard.controller.ts
+++ b/apps/api/src/player/leaderboards/player-leaderboard.controller.ts
@@ -17,7 +17,7 @@ export class PlayerLeaderboardsController {
   public constructor(private readonly playerLeaderboardService: PlayerLeaderboardService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Get a Player Leaderboard' })
+  @ApiOperation({ summary: 'Get a Player Leaderboard', tags: ['Player Leaderboards'] })
   @ApiOkResponse({ type: PostPlayerLeaderboardResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Auth({ weight: 3 })
@@ -44,7 +44,7 @@ export class PlayerLeaderboardsController {
   }
 
   @Post('/rankings')
-  @ApiOperation({ summary: 'Get a Player Rankings' })
+  @ApiOperation({ summary: 'Get a Player Rankings', tags: ['Player Leaderboards'] })
   @ApiOkResponse({ type: [PostPlayerRankingsResponse] })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Auth({ weight: 5 })

--- a/apps/api/src/player/player.controller.ts
+++ b/apps/api/src/player/player.controller.ts
@@ -25,7 +25,7 @@ export class PlayerController {
     private readonly hypixelService: HypixelService
   ) {}
 
-  @ApiOperation({ summary: 'Get a Player' })
+  @ApiOperation({ summary: 'Get a Player', tags: ['Player'] })
   @ApiOkResponse({ type: GetPlayerResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Auth()
@@ -39,7 +39,7 @@ export class PlayerController {
     };
   }
 
-  @ApiOperation({ summary: 'Deletes a Player' })
+  @ApiOperation({ summary: 'Deletes a Player', tags: ['Player'] })
   @ApiOkResponse({ type: SuccessResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Auth({ role: AuthRole.ADMIN })
@@ -52,7 +52,7 @@ export class PlayerController {
     };
   }
 
-  @ApiOperation({ summary: 'Get the Recent Games of a Player' })
+  @ApiOperation({ summary: 'Get the Recent Games of a Player', tags: ['Player'] })
   @ApiOkResponse({ type: GetRecentGamesResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Auth()
@@ -66,7 +66,7 @@ export class PlayerController {
     };
   }
 
-  @ApiOperation({ summary: 'Get the Status of a Player' })
+  @ApiOperation({ summary: 'Get the Status of a Player', tags: ['Player'] })
   @ApiOkResponse({ type: GetStatusResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Auth()
@@ -80,7 +80,7 @@ export class PlayerController {
     };
   }
 
-  @ApiOperation({ summary: 'Get the Friends of a Player' })
+  @ApiOperation({ summary: 'Get the Friends of a Player', tags: ['Player'] })
   @ApiOkResponse({ type: GetFriendsResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Auth({ weight: 10 })
@@ -94,7 +94,10 @@ export class PlayerController {
     };
   }
 
-  @ApiOperation({ summary: 'Get the Ranked SkyWars rating and position of a Player' })
+  @ApiOperation({
+    summary: 'Get the Ranked SkyWars rating and position of a Player',
+    tags: ['Player'],
+  })
   @ApiOkResponse({ type: GetRankedSkyWarsResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Auth()
@@ -108,7 +111,7 @@ export class PlayerController {
     };
   }
 
-  @ApiOperation({ summary: 'Get the Achievements of a Player' })
+  @ApiOperation({ summary: 'Get the Achievements of a Player', tags: ['Player'] })
   @ApiOkResponse({ type: GetAchievementsResponse })
   @ApiBadRequestResponse({ type: ErrorResponse })
   @Auth()

--- a/apps/api/src/skin/skin.controller.ts
+++ b/apps/api/src/skin/skin.controller.ts
@@ -11,7 +11,7 @@ export class SkinController {
   public constructor(private readonly skinService: SkinService) {}
 
   @Get('/head')
-  @ApiOperation({ summary: 'Get a Player Head' })
+  @ApiOperation({ summary: 'Get a Player Head', tags: ['Skins'] })
   @Auth()
   @ApiBadRequestResponse({ type: ErrorResponse })
   public async getHead(@Query() { uuid, size }: HeadDto) {
@@ -21,7 +21,7 @@ export class SkinController {
   }
 
   @Get()
-  @ApiOperation({ summary: 'Get a Player Render' })
+  @ApiOperation({ summary: 'Get a Player Render', tags: ['Skins'] })
   @Auth()
   @ApiBadRequestResponse({ type: ErrorResponse })
   public async getRender(@Query() { uuid }: UuidDto) {


### PR DESCRIPTION
# Description
Tags make the different category of endpoints into menus in swagger and redoc.
This is desirable due to the large amount of endpoints available with the various http methods as well.

Swagger tags documentation can be viewed [here](https://swagger.io/docs/specification/grouping-operations-with-tags/).

## With tags:
![image](https://user-images.githubusercontent.com/42223931/162892644-cf7e18a3-22e8-45b1-b7c1-c28fb9e65694.png)

## Without tags:
![image](https://user-images.githubusercontent.com/42223931/162892849-b310a334-4d80-4223-b95c-81e21ad49414.png)
