### PR TITLE
fix(schema): add duels coins

### DIFF
--- a/packages/schemas/src/player/gamemodes/quake/mode.ts
+++ b/packages/schemas/src/player/gamemodes/quake/mode.ts
@@ -21,6 +21,9 @@ export class QuakeMode {
   @Field({ leaderboard: { enabled: false } })
   public hkr: number;
 
+  @Field({ leaderboard: { enabled: false } })
+  public kwr: number;
+
   @Field()
   public killstreaks: number;
 
@@ -47,5 +50,6 @@ export class QuakeMode {
   public static applyRatios(data: QuakeMode) {
     data.kdr = ratio(data.kills, data.deaths);
     data.hkr = ratio(data.headShots, data.kills);
+    data.kwr = ratio(data.kills, data.wins);
   }
 }


### PR DESCRIPTION
In Quakecraft, there is not a tangible method to obtain a W/L ratio. As a result, almost all players have adopted the KWR stat in order to measure win rate instead. This is due to the fact that the way Quake works, it takes 25 kills to win a game, every single time. As a result, seeing how many kills it takes a person to obtain one win is a very accurate way to measure win rate in the absence of a true win/loss ratio. The Quake community has greatly requested this ratio, and adding it will greatly enhance the experience of those using the Quake command as it allows them to measure success in ways they were unable to using the bot before. This is a highly valued stat for many. 
