### PR TITLE
feat: add prefixes and level progression to more games

### DIFF
--- a/apps/discord-bot/src/commands/arenabrawl/arenabrawl.profile.tsx
+++ b/apps/discord-bot/src/commands/arenabrawl/arenabrawl.profile.tsx
@@ -8,7 +8,15 @@
 
 import { ArenaBrawlModes, FormattedGame, GameMode } from "@statsify/schemas";
 import { BaseProfileProps } from "../base.hypixel-command";
-import { Container, Footer, Header, Historical, SidebarItem, Table } from "#components";
+import {
+  Container,
+  Footer,
+  Header,
+  Historical,
+  SidebarItem,
+  Table,
+  formatProgression,
+} from "#components";
 import { prettify } from "@statsify/util";
 
 export interface ArenaBrawlProfileProps extends BaseProfileProps {
@@ -45,6 +53,12 @@ export const ArenaBrawlProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.ARENA_BRAWL} §fStats §r(${mode.formatted})`}
+        description={`${formatProgression({
+          t,
+          progression: arenabrawl.progression,
+          currentLevel: arenabrawl.currentPrefix,
+          nextLevel: arenabrawl.nextPrefix,
+        })}`}
         time={time}
       />
       <Table.table>

--- a/apps/discord-bot/src/commands/arenabrawl/arenabrawl.profile.tsx
+++ b/apps/discord-bot/src/commands/arenabrawl/arenabrawl.profile.tsx
@@ -53,7 +53,7 @@ export const ArenaBrawlProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.ARENA_BRAWL} §fStats §r(${mode.formatted})`}
-        description={`${formatProgression({
+        description={`§7Kill ${formatProgression({
           t,
           progression: arenabrawl.progression,
           currentLevel: arenabrawl.currentPrefix,

--- a/apps/discord-bot/src/commands/bedwars/bedwars.profile.tsx
+++ b/apps/discord-bot/src/commands/bedwars/bedwars.profile.tsx
@@ -56,9 +56,7 @@ export const BedWarsProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.BEDWARS} §fStats §r(${mode.formatted})`}
-        description={`${FormattedGame.BEDWARS} §7Level: ${
-          bedwars.levelFormatted
-        }\n${formatProgression({
+        description={`§7Level: ${bedwars.levelFormatted}\n${formatProgression({
           t,
           progression: bedwars.progression,
           currentLevel: bedwars.levelFormatted,

--- a/apps/discord-bot/src/commands/blitzsg/blitzsg.profile.tsx
+++ b/apps/discord-bot/src/commands/blitzsg/blitzsg.profile.tsx
@@ -14,7 +14,14 @@ import {
   FormattedGame,
   GameMode,
 } from "@statsify/schemas";
-import { Container, Footer, Header, SidebarItem, Table } from "#components";
+import {
+  Container,
+  Footer,
+  Header,
+  SidebarItem,
+  Table,
+  formatProgression,
+} from "#components";
 import { LocalizeFunction } from "@statsify/discord";
 import { formatTime, prettify, romanNumeral } from "@statsify/util";
 
@@ -156,6 +163,16 @@ export const BlitzSGProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.BLITZSG} §fStats §r(${mode.formatted})`}
+        description={
+          mode.api === "overall"
+            ? `§7Kill ${formatProgression({
+                t,
+                progression: blitzsg.progression,
+                currentLevel: blitzsg.currentPrefix,
+                nextLevel: blitzsg.nextPrefix,
+              })}`
+            : ""
+        }
         time={time}
       />
       {table}

--- a/apps/discord-bot/src/commands/buildbattle/buildbattle.profile.tsx
+++ b/apps/discord-bot/src/commands/buildbattle/buildbattle.profile.tsx
@@ -6,7 +6,14 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { Container, Footer, Header, SidebarItem, Table } from "#components";
+import {
+  Container,
+  Footer,
+  Header,
+  SidebarItem,
+  Table,
+  formatProgression,
+} from "#components";
 import { FormattedGame } from "@statsify/schemas";
 import { LocalizeFunction } from "@statsify/discord";
 import type { BaseProfileProps } from "../base.hypixel-command";
@@ -54,7 +61,13 @@ export const BuildBattleProfile = ({
         sidebar={sidebar}
         historicalSidebar
         title={`§l${FormattedGame.BUILD_BATTLE} §fStats`}
-        description={`§dBuild Battle Title\n${buildbattle.titleFormatted}`}
+        description={`§7Title: ${buildbattle.titleFormatted}\n${formatProgression({
+          t,
+          progression: buildbattle.progression,
+          currentLevel: buildbattle.titleFormatted,
+          nextLevel: buildbattle.nextTitleFormatted,
+          showLevelWhenMaxed: false,
+        })}`}
         time={time}
       />
       <Table.table>

--- a/apps/discord-bot/src/commands/duels/bridge.profile.tsx
+++ b/apps/discord-bot/src/commands/duels/bridge.profile.tsx
@@ -8,7 +8,15 @@
 
 import { BaseProfileProps } from "../base.hypixel-command";
 import { BridgeModes, FormattedGame, GameMode } from "@statsify/schemas";
-import { Container, Footer, Header, Historical, SidebarItem, Table } from "#components";
+import {
+  Container,
+  Footer,
+  Header,
+  Historical,
+  SidebarItem,
+  Table,
+  formatProgression,
+} from "#components";
 
 export interface BridgeProfileProps extends BaseProfileProps {
   mode: GameMode<BridgeModes>;
@@ -43,7 +51,13 @@ export const BridgeProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.BRIDGE} §fStats §r(${mode.formatted})`}
-        description={`§dBridge Title\n${bridge.titleFormatted}`}
+        description={`§7Title: ${bridge.titleFormatted}\n${formatProgression({
+          t,
+          progression: bridge.progression,
+          currentLevel: bridge.titleLevelFormatted,
+          nextLevel: bridge.nextTitleLevelFormatted,
+          showLevelWhenMaxed: false,
+        })}`}
         time={time}
       />
       <Table.table>

--- a/apps/discord-bot/src/commands/duels/duels.profile.tsx
+++ b/apps/discord-bot/src/commands/duels/duels.profile.tsx
@@ -13,7 +13,7 @@ import {
   SingleDuelsGameModeTable,
   UHCDuelsTable,
 } from "./tables";
-import { Container, Footer, Header, SidebarItem } from "#components";
+import { Container, Footer, Header, SidebarItem, formatProgression } from "#components";
 import { DuelsModes, FormattedGame, GameMode } from "@statsify/schemas";
 
 export interface DuelsProfileProps extends BaseProfileProps {
@@ -68,7 +68,13 @@ export const DuelsProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.DUELS} §fStats §r(${mode.formatted})`}
-        description={`§d${mode.formatted} Title\n${duels[api].titleFormatted}`}
+        description={`§7Title: ${duels[api].titleFormatted}\n${formatProgression({
+          t,
+          progression: duels[api].progression,
+          currentLevel: duels[api].titleLevelFormatted,
+          nextLevel: duels[api].nextTitleLevelFormatted,
+          showLevelWhenMaxed: false,
+        })}`}
         time={time}
       />
       {table}

--- a/apps/discord-bot/src/commands/historical/historical.base.tsx
+++ b/apps/discord-bot/src/commands/historical/historical.base.tsx
@@ -234,7 +234,9 @@ export class HistoricalBase {
 
   @SubCommand({ description: (t) => t("commands.historical-vampirez"), args })
   public vampirez(context: CommandContext) {
-    return this.run(context, VAMPIREZ_MODES, (base) => <VampireZProfile {...base} />);
+    return this.run(context, VAMPIREZ_MODES, (base, mode) => (
+      <VampireZProfile {...base} mode={mode} />
+    ));
   }
 
   @SubCommand({ description: (t) => t("commands.historical-walls"), args })

--- a/apps/discord-bot/src/commands/murdermystery/murdermystery.profile.tsx
+++ b/apps/discord-bot/src/commands/murdermystery/murdermystery.profile.tsx
@@ -186,7 +186,11 @@ export const MurderMysteryProfile = ({
       table = (
         <Table.table>
           <Table.tr>
-            <Table.td title={t("stats.wins")} value={t(stats.wins)} color="§a" />
+            <Table.td
+              title={t("stats.infectedWins")}
+              value={t(stats.infectedWins)}
+              color="§a"
+            />
             <Table.td
               title={t("stats.killsAsInfected")}
               value={t(stats.killsAsInfected)}

--- a/apps/discord-bot/src/commands/paintball/paintball.profile.tsx
+++ b/apps/discord-bot/src/commands/paintball/paintball.profile.tsx
@@ -7,7 +7,15 @@
  */
 
 import { BaseProfileProps } from "../base.hypixel-command";
-import { Container, Footer, Header, Historical, SidebarItem, Table } from "#components";
+import {
+  Container,
+  Footer,
+  Header,
+  Historical,
+  SidebarItem,
+  Table,
+  formatProgression,
+} from "#components";
 import { FormattedGame } from "@statsify/schemas";
 import { formatTime, prettify } from "@statsify/util";
 
@@ -39,6 +47,12 @@ export const PaintballProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.PAINTBALL} §fStats`}
+        description={`${formatProgression({
+          t,
+          progression: paintball.progression,
+          currentLevel: paintball.currentPrefix,
+          nextLevel: paintball.nextPrefix,
+        })}`}
         time={time}
       />
       <Table.table>

--- a/apps/discord-bot/src/commands/paintball/paintball.profile.tsx
+++ b/apps/discord-bot/src/commands/paintball/paintball.profile.tsx
@@ -47,7 +47,7 @@ export const PaintballProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.PAINTBALL} §fStats`}
-        description={`${formatProgression({
+        description={`§7Kill ${formatProgression({
           t,
           progression: paintball.progression,
           currentLevel: paintball.currentPrefix,

--- a/apps/discord-bot/src/commands/quake/quake.profile.tsx
+++ b/apps/discord-bot/src/commands/quake/quake.profile.tsx
@@ -7,7 +7,14 @@
  */
 
 import { BaseProfileProps } from "../base.hypixel-command";
-import { Container, Footer, Header, SidebarItem, Table } from "#components";
+import {
+  Container,
+  Footer,
+  Header,
+  SidebarItem,
+  Table,
+  formatProgression,
+} from "#components";
 import { FormattedGame, GameMode, QuakeModes } from "@statsify/schemas";
 
 export interface QuakeProfileProps extends BaseProfileProps {
@@ -44,6 +51,12 @@ export const QuakeProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.QUAKE} §fStats §r(${mode.formatted})`}
+        description={`${formatProgression({
+          t,
+          progression: quake.progression,
+          currentLevel: quake.currentPrefix,
+          nextLevel: quake.nextPrefix,
+        })}`}
         time={time}
       />
       <Table.table>

--- a/apps/discord-bot/src/commands/quake/quake.profile.tsx
+++ b/apps/discord-bot/src/commands/quake/quake.profile.tsx
@@ -51,7 +51,7 @@ export const QuakeProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.QUAKE} §fStats §r(${mode.formatted})`}
-        description={`${formatProgression({
+        description={`§7Kill ${formatProgression({
           t,
           progression: quake.progression,
           currentLevel: quake.currentPrefix,

--- a/apps/discord-bot/src/commands/skywars/skywars.profile.tsx
+++ b/apps/discord-bot/src/commands/skywars/skywars.profile.tsx
@@ -141,9 +141,7 @@ export const SkyWarsProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.SKYWARS} Stats §r(${mode.formatted})`}
-        description={`${FormattedGame.SKYWARS} §7Level: ${
-          skywars.levelFormatted
-        }\n${formatProgression({
+        description={`§7Level: ${skywars.levelFormatted}\n${formatProgression({
           t,
           progression: skywars.progression,
           currentLevel: skywars.levelFormatted,

--- a/apps/discord-bot/src/commands/smashheroes/smashheroes.profile.tsx
+++ b/apps/discord-bot/src/commands/smashheroes/smashheroes.profile.tsx
@@ -31,7 +31,8 @@ export const SmashHeroesProfile = ({
 
   const sidebar: SidebarItem[] = [
     [t("stats.coins"), t(smashheroes.coins), "§6"],
-    [t("stats.class"), prettify(smashheroes.kit), "§b"],
+    [t("stats.level"), t(smashheroes.levelFormatted), "§b"],
+    [t("stats.class"), prettify(smashheroes.kit), "§d"],
   ];
 
   return (
@@ -42,7 +43,6 @@ export const SmashHeroesProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.SMASH_HEROES} §fStats §r(${mode.formatted})`}
-        description={`${FormattedGame.SMASH_HEROES} §7Level: ${smashheroes.levelFormatted}`}
         time={time}
       />
       <Table.table>

--- a/apps/discord-bot/src/commands/speeduhc/speeduhc.profile.tsx
+++ b/apps/discord-bot/src/commands/speeduhc/speeduhc.profile.tsx
@@ -7,7 +7,15 @@
  */
 
 import { BaseProfileProps } from "../base.hypixel-command";
-import { Container, Footer, Header, If, SidebarItem, Table } from "#components";
+import {
+  Container,
+  Footer,
+  Header,
+  If,
+  SidebarItem,
+  Table,
+  formatProgression,
+} from "#components";
 import { FormattedGame, GameMode, SpeedUHCMode, SpeedUHCModes } from "@statsify/schemas";
 import { prettify } from "@statsify/util";
 
@@ -44,7 +52,12 @@ export const SpeedUHCProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.SPEED_UHC} §fStats §r(${mode.formatted})`}
-        description={`${FormattedGame.SPEED_UHC} §7Level: ${speeduhc.levelFormatted}`}
+        description={`§7Level: ${speeduhc.levelFormatted}\n${formatProgression({
+          t,
+          progression: speeduhc.progression,
+          currentLevel: speeduhc.levelFormatted,
+          nextLevel: speeduhc.nextLevelFormatted,
+        })}`}
         time={time}
         historicalSidebar
       />

--- a/apps/discord-bot/src/commands/turbokartracers/turbokartracers.profile.tsx
+++ b/apps/discord-bot/src/commands/turbokartracers/turbokartracers.profile.tsx
@@ -45,7 +45,7 @@ export const TurboKartRacersProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.TURBO_KART_RACERS} §fStats`}
-        description={`${formatProgression({
+        description={`§7Gold Trophy ${formatProgression({
           t,
           progression: turbokartracers.progression,
           currentLevel: turbokartracers.currentPrefix,

--- a/apps/discord-bot/src/commands/turbokartracers/turbokartracers.profile.tsx
+++ b/apps/discord-bot/src/commands/turbokartracers/turbokartracers.profile.tsx
@@ -7,7 +7,14 @@
  */
 
 import { BaseProfileProps } from "../base.hypixel-command";
-import { Container, Footer, Header, SidebarItem, Table } from "#components";
+import {
+  Container,
+  Footer,
+  Header,
+  SidebarItem,
+  Table,
+  formatProgression,
+} from "#components";
 import { FormattedGame } from "@statsify/schemas";
 
 export const TurboKartRacersProfile = ({
@@ -38,6 +45,12 @@ export const TurboKartRacersProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.TURBO_KART_RACERS} §fStats`}
+        description={`${formatProgression({
+          t,
+          progression: turbokartracers.progression,
+          currentLevel: turbokartracers.currentPrefix,
+          nextLevel: turbokartracers.nextPrefix,
+        })}`}
         time={time}
       />
       <Table.table>

--- a/apps/discord-bot/src/commands/uhc/uhc.profile.tsx
+++ b/apps/discord-bot/src/commands/uhc/uhc.profile.tsx
@@ -7,7 +7,14 @@
  */
 
 import { BaseProfileProps } from "../base.hypixel-command";
-import { Container, Footer, Header, SidebarItem, Table } from "#components";
+import {
+  Container,
+  Footer,
+  Header,
+  SidebarItem,
+  Table,
+  formatProgression,
+} from "#components";
 import { FormattedGame, GameMode, UHCModes } from "@statsify/schemas";
 import { prettify } from "@statsify/util";
 
@@ -44,7 +51,12 @@ export const UHCProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.UHC} §fStats §r(${mode.formatted})`}
-        description={`${FormattedGame.UHC} §7Level: ${uhc.levelFormatted}`}
+        description={`§7Level: ${uhc.levelFormatted}\n${formatProgression({
+          t,
+          progression: uhc.progression,
+          currentLevel: uhc.levelFormatted,
+          nextLevel: uhc.nextLevelFormatted,
+        })}`}
         time={time}
         historicalSidebar
       />

--- a/apps/discord-bot/src/commands/vampirez/vampirez.command.tsx
+++ b/apps/discord-bot/src/commands/vampirez/vampirez.command.tsx
@@ -6,7 +6,11 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { BaseHypixelCommand, BaseProfileProps } from "../base.hypixel-command";
+import {
+  BaseHypixelCommand,
+  BaseProfileProps,
+  ProfileData,
+} from "../base.hypixel-command";
 import { Command } from "@statsify/discord";
 import { VAMPIREZ_MODES, VampireZModes } from "@statsify/schemas";
 import { VampireZProfile } from "./vampirez.profile";
@@ -17,7 +21,10 @@ export class VampireZCommand extends BaseHypixelCommand<VampireZModes> {
     super(VAMPIREZ_MODES);
   }
 
-  public getProfile(base: BaseProfileProps): JSX.Element {
-    return <VampireZProfile {...base} />;
+  public getProfile(
+    base: BaseProfileProps,
+    { mode }: ProfileData<VampireZModes, never>
+  ): JSX.Element {
+    return <VampireZProfile {...base} mode={mode} />;
   }
 }

--- a/apps/discord-bot/src/commands/vampirez/vampirez.profile.tsx
+++ b/apps/discord-bot/src/commands/vampirez/vampirez.profile.tsx
@@ -15,23 +15,11 @@ import {
   Table,
   formatProgression,
 } from "#components";
-import { FormattedGame, VampireZLife } from "@statsify/schemas";
-import { LocalizeFunction } from "@statsify/discord";
+import { FormattedGame, GameMode, VampireZModes } from "@statsify/schemas";
 
-interface VampireZColumnProps {
-  mode: string;
-  stats: VampireZLife;
-  t: LocalizeFunction;
+export interface VampireZProfileProps extends BaseProfileProps {
+  mode: GameMode<VampireZModes>;
 }
-
-const VampireZColumn = ({ mode, stats, t }: VampireZColumnProps) => (
-  <Table.ts title={mode}>
-    <Table.td title={t(`stats.wins`)} value={t(stats.wins)} color="§e" />
-    <Table.td title={t(`stats.kills`)} value={t(stats.kills)} color="§a" />
-    <Table.td title={t(`stats.deaths`)} value={t(stats.deaths)} color="§c" />
-    <Table.td title={t(`stats.kdr`)} value={t(stats.kdr)} color="§6" />
-  </Table.ts>
-);
 
 export const VampireZProfile = ({
   skin,
@@ -42,14 +30,17 @@ export const VampireZProfile = ({
   badge,
   t,
   time,
-}: BaseProfileProps) => {
+  mode,
+}: VampireZProfileProps) => {
   const { vampirez } = player.stats;
+  const { api } = mode;
 
   const sidebar: SidebarItem[] = [
     [t("stats.coins"), t(vampirez.coins), "§6"],
     [t("stats.tokens"), t(vampirez.tokens), "§e"],
-    [t("stats.mostVampireKills"), t(vampirez.mostVampireKills), "§c"],
+    [t("stats.overallWins"), t(vampirez.overallWins), "§a"],
     [t("stats.zombieKills"), t(vampirez.zombieKills), "§2"],
+    [t("stats.mostVampireKills"), t(vampirez.mostVampireKills), "§c"],
   ];
 
   return (
@@ -59,20 +50,25 @@ export const VampireZProfile = ({
         name={player.prefixName}
         badge={badge}
         sidebar={sidebar}
-        title={`§l${FormattedGame.VAMPIREZ} §fStats`}
+        title={`§l${FormattedGame.VAMPIREZ} §fStats §r(${mode.formatted})`}
         description={`§7Win ${formatProgression({
           t,
-          progression: vampirez.progression,
-          currentLevel: vampirez.currentPrefix,
-          nextLevel: vampirez.nextPrefix,
+          progression: vampirez[api].progression,
+          currentLevel: vampirez[api].currentPrefix,
+          nextLevel: vampirez[api].nextPrefix,
         })}`}
         time={time}
       />
       <Table.table>
         <Table.tr>
-          <VampireZColumn mode="§6Overall" stats={vampirez.overall} t={t} />
-          <VampireZColumn mode="§eHuman" stats={vampirez.human} t={t} />
-          <VampireZColumn mode="§4Vampire" stats={vampirez.vampire} t={t} />
+          <Table.td title={t(`stats.wins`)} value={t(vampirez[api].wins)} color="§e" />
+          <Table.td title={t(`stats.kills`)} value={t(vampirez[api].kills)} color="§a" />
+          <Table.td
+            title={t(`stats.deaths`)}
+            value={t(vampirez[api].deaths)}
+            color="§c"
+          />
+          <Table.td title={t(`stats.kdr`)} value={t(vampirez[api].kdr)} color="§6" />
         </Table.tr>
       </Table.table>
       <Footer logo={logo} user={user} />

--- a/apps/discord-bot/src/commands/vampirez/vampirez.profile.tsx
+++ b/apps/discord-bot/src/commands/vampirez/vampirez.profile.tsx
@@ -60,7 +60,7 @@ export const VampireZProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.VAMPIREZ} §fStats`}
-        description={`${formatProgression({
+        description={`§7Win ${formatProgression({
           t,
           progression: vampirez.progression,
           currentLevel: vampirez.currentPrefix,

--- a/apps/discord-bot/src/commands/vampirez/vampirez.profile.tsx
+++ b/apps/discord-bot/src/commands/vampirez/vampirez.profile.tsx
@@ -7,7 +7,14 @@
  */
 
 import { BaseProfileProps } from "../base.hypixel-command";
-import { Container, Footer, Header, SidebarItem, Table } from "#components";
+import {
+  Container,
+  Footer,
+  Header,
+  SidebarItem,
+  Table,
+  formatProgression,
+} from "#components";
 import { FormattedGame, VampireZLife } from "@statsify/schemas";
 import { LocalizeFunction } from "@statsify/discord";
 
@@ -53,6 +60,12 @@ export const VampireZProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.VAMPIREZ} §fStats`}
+        description={`${formatProgression({
+          t,
+          progression: vampirez.progression,
+          currentLevel: vampirez.currentPrefix,
+          nextLevel: vampirez.nextPrefix,
+        })}`}
         time={time}
       />
       <Table.table>

--- a/apps/discord-bot/src/commands/walls/walls.profile.tsx
+++ b/apps/discord-bot/src/commands/walls/walls.profile.tsx
@@ -42,7 +42,7 @@ export const WallsProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.WALLS} §fStats`}
-        description={`${formatProgression({
+        description={`§7Win ${formatProgression({
           t,
           progression: walls.progression,
           currentLevel: walls.currentPrefix,

--- a/apps/discord-bot/src/commands/walls/walls.profile.tsx
+++ b/apps/discord-bot/src/commands/walls/walls.profile.tsx
@@ -7,7 +7,14 @@
  */
 
 import { BaseProfileProps } from "../base.hypixel-command";
-import { Container, Footer, Header, SidebarItem, Table } from "#components";
+import {
+  Container,
+  Footer,
+  Header,
+  SidebarItem,
+  Table,
+  formatProgression,
+} from "#components";
 import { FormattedGame } from "@statsify/schemas";
 
 export const WallsProfile = ({
@@ -35,6 +42,12 @@ export const WallsProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.WALLS} §fStats`}
+        description={`${formatProgression({
+          t,
+          progression: walls.progression,
+          currentLevel: walls.currentPrefix,
+          nextLevel: walls.nextPrefix,
+        })}`}
         time={time}
       />
       <Table.table>

--- a/apps/discord-bot/src/commands/woolwars/woolwars.profile.tsx
+++ b/apps/discord-bot/src/commands/woolwars/woolwars.profile.tsx
@@ -58,9 +58,7 @@ export const WoolWarsProfile = ({
         badge={badge}
         sidebar={sidebar}
         title={`§l${FormattedGame.WOOLWARS} §fStats §r(${mode.formatted})`}
-        description={`${FormattedGame.WOOLWARS} §7Level: ${
-          woolwars.levelFormatted
-        }\n${formatProgression({
+        description={`§7Level: ${woolwars.levelFormatted}\n${formatProgression({
           t,
           progression: woolwars.progression,
           currentLevel: woolwars.levelFormatted,

--- a/apps/discord-bot/src/components/Header/progression.ts
+++ b/apps/discord-bot/src/components/Header/progression.ts
@@ -33,6 +33,8 @@ export interface FormatProgressionOptions {
   nextLevel: string;
   showProgress?: boolean;
   showLevel?: boolean;
+
+  showLevelWhenMaxed?: boolean;
   renderXp?: ProgressFunction;
 }
 
@@ -43,6 +45,7 @@ export const formatProgression = ({
   nextLevel,
   showLevel = true,
   showProgress = true,
+  showLevelWhenMaxed = true,
   renderXp = xpBar,
 }: FormatProgressionOptions) => {
   if (progression.max) {
@@ -61,8 +64,8 @@ export const formatProgression = ({
 
   let output = "§^2^";
 
-  if (showLevel) output += `§l${currentLevel} `;
-  output += "§r§8(§b§lMAXED§r§8)";
+  output += "§7Progress: ";
+  output += showLevelWhenMaxed ? `${currentLevel} §r§8(§b§lMAXED§r§8)` : "§r§b§lMAXED§r";
 
   return output;
 };

--- a/apps/discord-bot/src/lib/command.listener.ts
+++ b/apps/discord-bot/src/lib/command.listener.ts
@@ -30,6 +30,8 @@ import type {
   WebsocketShard,
 } from "tiny-discord";
 
+const isDevelopment = config("environment") === "dev";
+
 export class CommandListener extends AbstractCommandListener {
   private cooldowns: Map<string, Map<string, number>>;
   private readonly apiService: ApiService;
@@ -112,6 +114,8 @@ export class CommandListener extends AbstractCommandListener {
     user: User | null,
     userId: string
   ) {
+    if (isDevelopment) return true;
+
     const cooldownForCommand = this.cooldowns.get(command.name);
 
     let reduction = 1;

--- a/locales/en-US/default.json
+++ b/locales/en-US/default.json
@@ -501,7 +501,7 @@
     "challenges": "Challenges",
     "class": "Class",
     "coins": "Coins",
-    "correctGuesses": "Right Guesses",
+    "correctGuesses": "Correct Guesses",
     "damage": "Damage",
     "deaths": "Deaths",
     "detectiveWins": "Detective Wins",

--- a/packages/schemas/src/player/gamemodes/arenabrawl/index.ts
+++ b/packages/schemas/src/player/gamemodes/arenabrawl/index.ts
@@ -91,9 +91,11 @@ export class ArenaBrawl {
     this.overall = deepAdd(this.solo, this.doubles, this.fours);
 
     this.currentPrefix = getFormattedLevel(prefixes, this.overall.wins);
+    // this.naturalPrefix = getFormattedLevel(prefixes, this.overall.wins);
     this.nextPrefix = getFormattedLevel(prefixes, this.overall.wins, true);
+
     this.progression = new Progression(
-      Math.abs(this.overall.wins - getPrefixRequirement(prefixes, this.overall.wins)),
+      Math.abs(getPrefixRequirement(prefixes, this.overall.wins) - this.overall.wins),
       getPrefixRequirement(prefixes, this.overall.wins, 1) -
         getPrefixRequirement(prefixes, this.overall.wins)
     );

--- a/packages/schemas/src/player/gamemodes/arenabrawl/index.ts
+++ b/packages/schemas/src/player/gamemodes/arenabrawl/index.ts
@@ -41,6 +41,11 @@ export class ArenaBrawl {
   @Field()
   public currentPrefix: string;
 
+  @Field({
+    store: { default: getFormattedLevel({ prefixes, prefixScore: prefixes[0].score }) },
+  })
+  public naturalPrefix: string;
+
   @Field()
   public nextPrefix: string;
 
@@ -89,9 +94,18 @@ export class ArenaBrawl {
     this.fours = new ArenaBrawlMode(data, "4v4");
     this.overall = deepAdd(this.solo, this.doubles, this.fours);
 
-    this.currentPrefix = getFormattedLevel(prefixes, this.overall.wins);
-    // this.naturalPrefix = getFormattedLevel(prefixes, this.overall.wins);
-    this.nextPrefix = getFormattedLevel(prefixes, this.overall.wins, true);
+    const prefixScore = this.overall.wins;
+    this.currentPrefix = getFormattedLevel({ prefixes, prefixScore });
+    this.naturalPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      trueScore: true,
+    });
+    this.nextPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      skip: true,
+    });
 
     this.progression = new Progression(
       Math.abs(getPrefixRequirement(prefixes, this.overall.wins) - this.overall.wins),

--- a/packages/schemas/src/player/gamemodes/arenabrawl/index.ts
+++ b/packages/schemas/src/player/gamemodes/arenabrawl/index.ts
@@ -30,8 +30,7 @@ const prefixes = [
   { color: "c", score: 5000 },
   { color: "4", score: 7500 },
   { color: "6", score: 10_000 },
-  //TODO(@cody): Make this rainbow
-  { color: "1", score: 15_000 },
+  { color: "rainbow", score: 15_000 },
 ];
 export type ArenaBrawlModes = IGameModes<typeof ARENA_BRAWL_MODES>;
 

--- a/packages/schemas/src/player/gamemodes/blitzsg/index.ts
+++ b/packages/schemas/src/player/gamemodes/blitzsg/index.ts
@@ -99,6 +99,11 @@ export class BlitzSG {
   @Field()
   public currentPrefix: string;
 
+  @Field({
+    store: { default: getFormattedLevel({ prefixes, prefixScore: prefixes[0].score }) },
+  })
+  public naturalPrefix: string;
+
   @Field()
   public nextPrefix: string;
 
@@ -242,8 +247,18 @@ export class BlitzSG {
 
     this.overall = new BlitzSGOverall(data);
 
-    this.currentPrefix = getFormattedLevel(prefixes, this.overall.kills);
-    this.nextPrefix = getFormattedLevel(prefixes, this.overall.kills, true);
+    const prefixScore = this.overall.kills;
+    this.currentPrefix = getFormattedLevel({ prefixes, prefixScore });
+    this.naturalPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      trueScore: true,
+    });
+    this.nextPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      skip: true,
+    });
 
     this.progression = new Progression(
       Math.abs(this.overall.kills - getPrefixRequirement(prefixes, this.overall.kills)),

--- a/packages/schemas/src/player/gamemodes/blitzsg/index.ts
+++ b/packages/schemas/src/player/gamemodes/blitzsg/index.ts
@@ -6,11 +6,12 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { APIData } from "@statsify/util";
+import { APIData, getFormattedLevel, getPrefixRequirement } from "@statsify/util";
 import { BlitzSGKit } from "./kit";
 import { BlitzSGMode, BlitzSGOverall } from "./mode";
 import { Field } from "../../../metadata";
 import { GameModes, IGameModes } from "../../../game";
+import { Progression } from "../../../progression";
 import { sub } from "@statsify/math";
 
 export const BLITZSG_MODES = new GameModes([
@@ -64,6 +65,19 @@ export const BLITZSG_MODES = new GameModes([
   { hypixel: "teams_normal", formatted: "Doubles" },
 ]);
 
+const prefixes = [
+  { color: "7", score: 0 },
+  { color: "e", score: 1000 },
+  { color: "a", score: 25_000 },
+  { color: "c", score: 50_000 },
+  { color: "b", score: 75_000 },
+  { color: "6", score: 100_000 },
+  { color: "d", score: 150_000 },
+  { color: "4", score: 200_000 },
+  { color: "9", score: 250_000 },
+  { color: "2", score: 300_000 },
+];
+
 export type BlitzSGModes = IGameModes<typeof BLITZSG_MODES>;
 
 export class BlitzSG {
@@ -78,6 +92,15 @@ export class BlitzSG {
 
   @Field()
   public solo: BlitzSGMode;
+
+  @Field()
+  public progression: Progression;
+
+  @Field()
+  public currentPrefix: string;
+
+  @Field()
+  public nextPrefix: string;
 
   @Field()
   public doubles: BlitzSGMode;
@@ -218,6 +241,15 @@ export class BlitzSG {
     this.kit = data.defaultkit || "none";
 
     this.overall = new BlitzSGOverall(data);
+
+    this.currentPrefix = getFormattedLevel(prefixes, this.overall.kills);
+    this.nextPrefix = getFormattedLevel(prefixes, this.overall.kills, true);
+
+    this.progression = new Progression(
+      Math.abs(this.overall.kills - getPrefixRequirement(prefixes, this.overall.kills)),
+      getPrefixRequirement(prefixes, this.overall.kills, 1) -
+        getPrefixRequirement(prefixes, this.overall.kills)
+    );
 
     this.solo = new BlitzSGMode(data, "");
     this.doubles = new BlitzSGMode(data, "teams_normal");

--- a/packages/schemas/src/player/gamemodes/buildbattle/index.ts
+++ b/packages/schemas/src/player/gamemodes/buildbattle/index.ts
@@ -6,7 +6,7 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { APIData } from "@statsify/util";
+import { APIData, getPrefixRequirement } from "@statsify/util";
 import {
   BuildBattleGuessTheBuild,
   BuildBattleMultiplayerMode,
@@ -15,6 +15,7 @@ import {
 } from "./mode";
 import { Field } from "../../../metadata";
 import { GameModes, IGameModes } from "../../../game";
+import { Progression } from "../../../progression";
 import { getTitleIndex, titleScores } from "./util";
 
 export const BUILD_BATTLE_MODES = new GameModes([
@@ -26,6 +27,11 @@ export const BUILD_BATTLE_MODES = new GameModes([
   { hypixel: "BUILD_BATTLE_SOLO_NORMAL", formatted: "Solo" },
   { hypixel: "BUILD_BATTLE_SOLO_PRO", formatted: "Pro" },
 ]);
+
+const prefixes = titleScores.map((title) => ({
+  color: title.color,
+  score: title.req,
+}));
 
 export type BuildBattleModes = IGameModes<typeof BUILD_BATTLE_MODES>;
 
@@ -66,6 +72,12 @@ export class BuildBattle {
   @Field({ store: { default: `${titleScores[0].color}${titleScores[0].title}` } })
   public titleFormatted: string;
 
+  @Field()
+  public progression: Progression;
+
+  @Field()
+  public nextTitleFormatted: string;
+
   @Field({ leaderboard: { fieldName: "Wins", name: "1.14 Wins" } })
   public latestWins: number;
 
@@ -91,6 +103,15 @@ export class BuildBattle {
 
     this.title = title;
     this.titleFormatted = `${color}${title}`;
+    this.nextTitleFormatted = `${
+      titleScores[Math.min(titleScores.length - 1, index + 1)].color
+    }${titleScores[Math.min(titleScores.length - 1, index + 1)].title}`;
+
+    this.progression = new Progression(
+      Math.abs(getPrefixRequirement(prefixes, this.score) - this.score),
+      getPrefixRequirement(prefixes, this.score, 1) -
+        getPrefixRequirement(prefixes, this.score)
+    );
   }
 }
 

--- a/packages/schemas/src/player/gamemodes/buildbattle/util.ts
+++ b/packages/schemas/src/player/gamemodes/buildbattle/util.ts
@@ -10,7 +10,7 @@ import { findScoreIndex } from "@statsify/util";
 
 export const titleScores = [
   { req: 0, color: "§f", title: "Rookie" },
-  { req: 100, color: "§7", title: "Untrained" },
+  { req: 100, color: "§8", title: "Untrained" },
   { req: 250, color: "§e", title: "Amateur" },
   { req: 500, color: "§a", title: "Apprentice" },
   { req: 1000, color: "§d", title: "Experienced" },

--- a/packages/schemas/src/player/gamemodes/duels/index.ts
+++ b/packages/schemas/src/player/gamemodes/duels/index.ts
@@ -67,10 +67,10 @@ export class Duels {
   @Field({ store: { default: 300 }, leaderboard: { enabled: false } })
   public pingRange: number;
 
-  @Field()
+  @Field({ leaderboard: { extraDisplay: "stats.duels.overall.titleFormatted" } })
   public coins: number;
 
-  @Field()
+  @Field({ leaderboard: { extraDisplay: "stats.duels.overall.titleFormatted" } })
   public lootChests: number;
 
   @Field({ leaderboard: { extraDisplay: "stats.duels.overall.titleFormatted" } })

--- a/packages/schemas/src/player/gamemodes/duels/util.ts
+++ b/packages/schemas/src/player/gamemodes/duels/util.ts
@@ -9,11 +9,8 @@
 import { Color } from "../../../color";
 import { findScore, removeFormatting, romanNumeral } from "@statsify/util";
 
-export const getTitle = (wins: number, prefix: string) => {
-  const isOverall = prefix === "";
-  prefix = prefix ? `${prefix} ` : prefix;
-
-  const titleScores = [
+export const titleScores = (isOverall = false) =>
+  [
     { req: 0, inc: 0, title: "None", color: new Color("GRAY") },
     { req: 50, inc: 10, title: "Rookie", color: new Color("DARK_GRAY") },
     { req: 100, inc: 30, title: "Iron", color: new Color("WHITE") },
@@ -69,6 +66,10 @@ export const getTitle = (wins: number, prefix: string) => {
     inc: data.inc * (isOverall ? 2 : 1),
   }));
 
+export const getTitle = (wins: number, prefix: string) => {
+  const isOverall = prefix === "";
+  prefix = prefix ? `${prefix} ` : prefix;
+
   const {
     req,
     inc,
@@ -77,7 +78,7 @@ export const getTitle = (wins: number, prefix: string) => {
     bold = false,
     semi = false,
     max,
-  } = findScore(titleScores, wins);
+  } = findScore(titleScores(isOverall), wins);
 
   const remaining = wins - req;
   let index = (inc ? Math.floor(remaining / inc) : inc) + 1;
@@ -91,6 +92,12 @@ export const getTitle = (wins: number, prefix: string) => {
   return {
     formatted,
     color,
+    bold,
+    semi,
     raw: removeFormatting(formatted),
+    max,
+    req,
+    inc,
+    index,
   };
 };

--- a/packages/schemas/src/player/gamemodes/murdermystery/index.ts
+++ b/packages/schemas/src/player/gamemodes/murdermystery/index.ts
@@ -72,7 +72,7 @@ export class MurderMystery {
     this.assassins = new AssassinsMurderMysteryMode(data, "MURDER_ASSASSINS");
     this.infection = new InfectionMurderMysteryMode(data, "MURDER_INFECTION", ap);
 
-    ap.murdermystery_countermeasures;
+    this.overall.heroWins = ap.murdermystery_countermeasures;
   }
 }
 

--- a/packages/schemas/src/player/gamemodes/murdermystery/index.ts
+++ b/packages/schemas/src/player/gamemodes/murdermystery/index.ts
@@ -70,9 +70,9 @@ export class MurderMystery {
     this.classic = new ClassicMurderMysteryMode(data, "MURDER_CLASSIC");
     this.doubleUp = new ClassicMurderMysteryMode(data, "MURDER_DOUBLE_UP");
     this.assassins = new AssassinsMurderMysteryMode(data, "MURDER_ASSASSINS");
-    this.infection = new InfectionMurderMysteryMode(data, "MURDER_INFECTION");
+    this.infection = new InfectionMurderMysteryMode(data, "MURDER_INFECTION", ap);
 
-    this.overall.heroWins = ap.murdermystery_countermeasures;
+    ap.murdermystery_countermeasures;
   }
 }
 

--- a/packages/schemas/src/player/gamemodes/murdermystery/mode.ts
+++ b/packages/schemas/src/player/gamemodes/murdermystery/mode.ts
@@ -121,16 +121,13 @@ export class InfectionMurderMysteryMode extends BaseMurderMysteryMode {
   @Field({ leaderboard: { formatter: formatTime } })
   public longestSurvivalTime: number;
 
-  public constructor(data: APIData, mode: string) {
+  public constructor(data: APIData, mode: string, ap: APIData) {
     super(data, mode);
-    /*
-total_time_survived_seconds
-*/
-    this.survivorWins = data.survivor_wins_MURDER_INFECTION;
+
+    this.survivorWins = ap.murdermystery_survival_skills;
     this.killsAsSurvivor = data.kills_as_survivor_MURDER_INFECTION;
 
-    // Can be negative for some reason
-    this.infectedWins = Math.max(sub(this.wins, this.survivorWins), 0);
+    this.infectedWins = sub(this.wins, this.survivorWins);
     this.killsAsInfected = data.kills_as_infected_MURDER_INFECTION;
     this.lastAliveGames = data.last_one_alive_MURDER_INFECTION;
     this.longestSurvivalTime =

--- a/packages/schemas/src/player/gamemodes/paintball/index.ts
+++ b/packages/schemas/src/player/gamemodes/paintball/index.ts
@@ -75,6 +75,11 @@ export class Paintball {
   @Field()
   public currentPrefix: string;
 
+  @Field({
+    store: { default: getFormattedLevel({ prefixes, prefixScore: prefixes[0].score }) },
+  })
+  public naturalPrefix: string;
+
   @Field()
   public nextPrefix: string;
 
@@ -92,8 +97,19 @@ export class Paintball {
     this.perks = new PaintballPerks(data);
     this.tokens = legacy.paintball_tokens;
 
-    this.currentPrefix = getFormattedLevel(prefixes, this.kills);
-    this.nextPrefix = getFormattedLevel(prefixes, this.kills, true);
+    const prefixScore = this.kills;
+    this.currentPrefix = getFormattedLevel({ prefixes, prefixScore });
+    this.naturalPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      trueScore: true,
+    });
+    this.nextPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      skip: true,
+    });
+
     this.progression = new Progression(
       Math.abs(this.kills - getPrefixRequirement(prefixes, this.kills)),
       getPrefixRequirement(prefixes, this.kills, 1) -

--- a/packages/schemas/src/player/gamemodes/paintball/index.ts
+++ b/packages/schemas/src/player/gamemodes/paintball/index.ts
@@ -6,15 +6,31 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { APIData } from "@statsify/util";
+import { APIData, getFormattedLevel, getPrefixRequirement } from "@statsify/util";
 import { Field } from "../../../metadata";
 import { GameModes, IGameModes } from "../../../game";
 import { PaintballPerks } from "./perks";
+import { Progression } from "../../../progression";
 import { ratio } from "@statsify/math";
 
 export const PAINTBALL_MODES = new GameModes([{ api: "overall" }]);
 
 export type PaintballModes = IGameModes<typeof PAINTBALL_MODES>;
+
+const prefixes = [
+  { color: "8", score: 0 },
+  { color: "7", score: 1000 },
+  { color: "f", score: 2500 },
+  { color: "2", score: 5000 },
+  { color: "e", score: 10_000 },
+  { color: "a", score: 20_000 },
+  { color: "9", score: 50_000 },
+  { color: "3", score: 75_000 },
+  { color: "d", score: 100_000 },
+  { color: "5", score: 200_000 },
+  { color: "4", score: 500_000 },
+  { color: "6", score: 1_000_000 },
+];
 
 export class Paintball {
   @Field()
@@ -53,6 +69,15 @@ export class Paintball {
   @Field()
   public tokens: number;
 
+  @Field()
+  public progression: Progression;
+
+  @Field()
+  public currentPrefix: string;
+
+  @Field()
+  public nextPrefix: string;
+
   public constructor(data: APIData, legacy: APIData) {
     this.coins = data.coins;
     this.forcefieldTime = (data.forcefieldTime ?? 0) * 1000;
@@ -66,6 +91,14 @@ export class Paintball {
     this.shotAccuracy = ratio(this.kills, this.shotsFired, 100);
     this.perks = new PaintballPerks(data);
     this.tokens = legacy.paintball_tokens;
+
+    this.currentPrefix = getFormattedLevel(prefixes, this.kills);
+    this.nextPrefix = getFormattedLevel(prefixes, this.kills, true);
+    this.progression = new Progression(
+      Math.abs(this.kills - getPrefixRequirement(prefixes, this.kills)),
+      getPrefixRequirement(prefixes, this.kills, 1) -
+        getPrefixRequirement(prefixes, this.kills)
+    );
   }
 }
 

--- a/packages/schemas/src/player/gamemodes/quake/index.ts
+++ b/packages/schemas/src/player/gamemodes/quake/index.ts
@@ -47,7 +47,7 @@ const prefixes = [
   { color: "5", score: 600_000 },
   { color: "c", score: 750_000 },
   { color: "6", score: 1_000_000 },
-  { color: "8", score: 2_000_000 },
+  { color: "0", score: 2_000_000 },
 ];
 
 export class Quake {
@@ -92,6 +92,7 @@ export class Quake {
 
     this.currentPrefix = getFormattedLevel(prefixes, this.overall.kills);
     this.nextPrefix = getFormattedLevel(prefixes, this.overall.kills, true);
+
     this.progression = new Progression(
       Math.abs(this.overall.kills - getPrefixRequirement(prefixes, this.overall.kills)),
       getPrefixRequirement(prefixes, this.overall.kills, 1) -

--- a/packages/schemas/src/player/gamemodes/quake/index.ts
+++ b/packages/schemas/src/player/gamemodes/quake/index.ts
@@ -6,9 +6,10 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { APIData } from "@statsify/util";
+import { APIData, getFormattedLevel, getPrefixRequirement } from "@statsify/util";
 import { Field } from "../../../metadata";
 import { GameModes, IGameModes } from "../../../game";
+import { Progression } from "../../../progression";
 import { QuakeMode } from "./mode";
 import { deepAdd } from "@statsify/math";
 
@@ -33,7 +34,32 @@ const indexes = [
   "nine",
 ];
 
+const prefixes = [
+  { color: "8", score: 0 },
+  { color: "7", score: 25_000 },
+  { color: "f", score: 50_000 },
+  { color: "2", score: 75_000 },
+  { color: "e", score: 100_000 },
+  { color: "a", score: 200_000 },
+  { color: "9", score: 300_000 },
+  { color: "3", score: 400_000 },
+  { color: "d", score: 500_000 },
+  { color: "5", score: 600_000 },
+  { color: "c", score: 750_000 },
+  { color: "6", score: 1_000_000 },
+  { color: "8", score: 2_000_000 },
+];
+
 export class Quake {
+  @Field()
+  public progression: Progression;
+
+  @Field()
+  public currentPrefix: string;
+
+  @Field()
+  public nextPrefix: string;
+
   @Field()
   public overall: QuakeMode;
 
@@ -64,12 +90,21 @@ export class Quake {
 
     this.overall = deepAdd(this.solo, this.teams);
 
+    this.currentPrefix = getFormattedLevel(prefixes, this.overall.kills);
+    this.nextPrefix = getFormattedLevel(prefixes, this.overall.kills, true);
+    this.progression = new Progression(
+      Math.abs(this.overall.kills - getPrefixRequirement(prefixes, this.overall.kills)),
+      getPrefixRequirement(prefixes, this.overall.kills, 1) -
+        getPrefixRequirement(prefixes, this.overall.kills)
+    );
+
     QuakeMode.applyRatios(this.overall);
 
     this.coins = data.coins;
     this.highestKillstreak = data.highest_killstreak;
     this.godlikes = ap.quake_godlikes;
     this.tokens = legacy.quakecraft_tokens;
+
     // NINE_POINT_ZERO becomes 9.0
     // ALWAYS in seconds
     this.trigger =

--- a/packages/schemas/src/player/gamemodes/quake/index.ts
+++ b/packages/schemas/src/player/gamemodes/quake/index.ts
@@ -57,6 +57,11 @@ export class Quake {
   @Field()
   public currentPrefix: string;
 
+  @Field({
+    store: { default: getFormattedLevel({ prefixes, prefixScore: prefixes[0].score }) },
+  })
+  public naturalPrefix: string;
+
   @Field()
   public nextPrefix: string;
 
@@ -90,8 +95,18 @@ export class Quake {
 
     this.overall = deepAdd(this.solo, this.teams);
 
-    this.currentPrefix = getFormattedLevel(prefixes, this.overall.kills);
-    this.nextPrefix = getFormattedLevel(prefixes, this.overall.kills, true);
+    const prefixScore = this.overall.kills;
+    this.currentPrefix = getFormattedLevel({ prefixes, prefixScore });
+    this.naturalPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      trueScore: true,
+    });
+    this.nextPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      skip: true,
+    });
 
     this.progression = new Progression(
       Math.abs(this.overall.kills - getPrefixRequirement(prefixes, this.overall.kills)),

--- a/packages/schemas/src/player/gamemodes/speeduhc/index.ts
+++ b/packages/schemas/src/player/gamemodes/speeduhc/index.ts
@@ -6,9 +6,10 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { APIData } from "@statsify/util";
+import { APIData, getPrefixRequirement } from "@statsify/util";
 import { Field } from "../../../metadata";
 import { GameModes, IGameModes } from "../../../game";
+import { Progression } from "../../../progression";
 import { SpeedUHCMastery } from "./mastery";
 import { SpeedUHCMode } from "./mode";
 import { getLevelIndex, titleScores } from "./util";
@@ -29,6 +30,11 @@ export const SPEED_UHC_MODES = new GameModes([
   { api: "fortune" },
   { api: "vampirism" },
 ]);
+
+const prefixes = titleScores.map((level) => ({
+  color: "6",
+  score: level.req,
+}));
 
 export type SpeedUHCModes = IGameModes<typeof SPEED_UHC_MODES>;
 
@@ -56,6 +62,12 @@ export class SpeedUHC {
 
   @Field({ store: { default: formatLevel(1) } })
   public levelFormatted: string;
+
+  @Field()
+  public nextLevelFormatted: string;
+
+  @Field()
+  public progression: Progression;
 
   @Field({ store: { default: titleScores[0].title } })
   public title: string;
@@ -110,6 +122,14 @@ export class SpeedUHC {
 
     this.level = index + 1;
     this.levelFormatted = formatLevel(this.level);
+    this.nextLevelFormatted = formatLevel(Math.floor(this.level) + 1);
+
+    this.progression = new Progression(
+      Math.abs(this.score - getPrefixRequirement(prefixes, this.score)),
+      getPrefixRequirement(prefixes, this.score, 1) -
+        getPrefixRequirement(prefixes, this.score)
+    );
+
     this.title = titleScores[index].title;
   }
 }

--- a/packages/schemas/src/player/gamemodes/turbokartracers/index.ts
+++ b/packages/schemas/src/player/gamemodes/turbokartracers/index.ts
@@ -6,14 +6,32 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { APIData } from "@statsify/util";
+import { APIData, getFormattedLevel, getPrefixRequirement } from "@statsify/util";
 import { Field } from "../../../metadata";
 import { GameModes, IGameModes } from "../../../game";
+import { Progression } from "../../../progression";
 import { add, ratio } from "@statsify/math";
 
 export const TURBO_KART_RACERS_MODES = new GameModes([{ api: "overall" }]);
 
 export type TurboKartRacersModes = IGameModes<typeof TURBO_KART_RACERS_MODES>;
+
+const prefixes = [
+  { color: "8", score: 0 },
+  { color: "7", score: 5 },
+  { color: "f", score: 25 },
+  { color: "3", score: 50 },
+  { color: "a", score: 100 },
+  { color: "e", score: 200 },
+  { color: "b", score: 300 },
+  { color: "d", score: 400 },
+  { color: "6", score: 500 },
+  { color: "2", score: 750 },
+  { color: "9", score: 1000 },
+  { color: "5", score: 2500 },
+  { color: "4", score: 5000 },
+  { color: "8", score: 10_000 },
+];
 
 export class TurboKartRacers {
   @Field()
@@ -55,6 +73,15 @@ export class TurboKartRacers {
   @Field({ leaderboard: { enabled: false } })
   public goldRate: number;
 
+  @Field()
+  public progression: Progression;
+
+  @Field()
+  public currentPrefix: string;
+
+  @Field()
+  public nextPrefix: string;
+
   public constructor(data: APIData, legacy: APIData) {
     this.coins = data.coins;
     this.tokens = legacy.tokens;
@@ -75,6 +102,14 @@ export class TurboKartRacers {
     this.silver = data.silver_trophy;
     this.gold = data.gold_trophy;
     this.total = add(this.gold, this.silver, this.bronze);
+
+    this.currentPrefix = getFormattedLevel(prefixes, this.gold);
+    this.nextPrefix = getFormattedLevel(prefixes, this.gold, true);
+    this.progression = new Progression(
+      Math.abs(this.gold - getPrefixRequirement(prefixes, this.gold)),
+      getPrefixRequirement(prefixes, this.gold, 1) -
+        getPrefixRequirement(prefixes, this.gold)
+    );
 
     this.goldRate = ratio(this.gold, this.gamesPlayed, 100);
     this.trophyRate = ratio(this.total, this.gamesPlayed, 100);

--- a/packages/schemas/src/player/gamemodes/turbokartracers/index.ts
+++ b/packages/schemas/src/player/gamemodes/turbokartracers/index.ts
@@ -79,6 +79,11 @@ export class TurboKartRacers {
   @Field()
   public currentPrefix: string;
 
+  @Field({
+    store: { default: getFormattedLevel({ prefixes, prefixScore: prefixes[0].score }) },
+  })
+  public naturalPrefix: string;
+
   @Field()
   public nextPrefix: string;
 
@@ -103,8 +108,19 @@ export class TurboKartRacers {
     this.gold = data.gold_trophy;
     this.total = add(this.gold, this.silver, this.bronze);
 
-    this.currentPrefix = getFormattedLevel(prefixes, this.gold);
-    this.nextPrefix = getFormattedLevel(prefixes, this.gold, true);
+    const prefixScore = this.gold;
+    this.currentPrefix = getFormattedLevel({ prefixes, prefixScore });
+    this.naturalPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      trueScore: true,
+    });
+    this.nextPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      skip: true,
+    });
+
     this.progression = new Progression(
       Math.abs(this.gold - getPrefixRequirement(prefixes, this.gold)),
       getPrefixRequirement(prefixes, this.gold, 1) -

--- a/packages/schemas/src/player/gamemodes/uhc/index.ts
+++ b/packages/schemas/src/player/gamemodes/uhc/index.ts
@@ -6,9 +6,10 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { APIData } from "@statsify/util";
+import { APIData, getPrefixRequirement } from "@statsify/util";
 import { Field } from "../../../metadata";
 import { GameModes, IGameModes } from "../../../game";
+import { Progression } from "../../../progression";
 import { UHCMode } from "./mode";
 import { deepAdd } from "@statsify/math";
 import { getLevelIndex, titleScores } from "./util";
@@ -20,6 +21,11 @@ export const UHC_MODES = new GameModes([
   { api: "solo", hypixel: "SOLO" },
   { api: "teams", hypixel: "TEAMS" },
 ]);
+
+const prefixes = titleScores.map((level) => ({
+  color: "6",
+  score: level.req,
+}));
 
 export type UHCModes = IGameModes<typeof UHC_MODES>;
 
@@ -43,6 +49,12 @@ export class UHC {
   public levelFormatted: string;
 
   @Field()
+  public nextLevelFormatted: string;
+
+  @Field()
+  public progression: Progression;
+
+  @Field()
   public score: number;
 
   @Field({ store: { default: "none" } })
@@ -59,8 +71,15 @@ export class UHC {
 
     const index = getLevelIndex(this.score);
 
+    this.progression = new Progression(
+      Math.abs(this.score - getPrefixRequirement(prefixes, this.score)),
+      getPrefixRequirement(prefixes, this.score, 1) -
+        getPrefixRequirement(prefixes, this.score)
+    );
+
     this.level = index + 1;
     this.levelFormatted = formatLevel(this.level);
+    this.nextLevelFormatted = formatLevel(Math.floor(this.level) + 1);
     this.title = titleScores[index].title;
 
     this.solo = new UHCMode(data, "solo");

--- a/packages/schemas/src/player/gamemodes/vampirez/index.ts
+++ b/packages/schemas/src/player/gamemodes/vampirez/index.ts
@@ -9,55 +9,11 @@
 import { APIData } from "@statsify/util";
 import { Field } from "../../../metadata";
 import { GameModes, IGameModes } from "../../../game";
-import { Progression } from "../../../progression";
 import { VampireZLife } from "./life";
 import { add } from "@statsify/math";
 
 export const VAMPIREZ_MODES = new GameModes([{ api: "human" }, { api: "vampire" }]);
 export type VampireZModes = IGameModes<typeof VAMPIREZ_MODES>;
-
-export const humanPrefixes = [
-  { color: "8", score: 0 },
-  { color: "7", score: 20 },
-  { color: "f", score: 50 },
-  { color: "6", score: 100 },
-  { color: "e", score: 150 },
-  { color: "2", score: 200 },
-  { color: "a", score: 250 },
-  { color: "5", score: 300 },
-  { color: "d", score: 500 },
-  { color: "1", score: 750 },
-  { color: "9§l", score: 1000 },
-  { color: "b§l", score: 1500 },
-  { color: "3§l", score: 2000 },
-  { color: "b§l", score: 2500 },
-  { color: "c§l", score: 3000 },
-  { color: "4§l", score: 5000 },
-  { color: "0§l", score: 7500 },
-  { color: "rainbow", score: 15_000 },
-];
-
-export const vampirePrefixes = [
-  { color: "8", score: 0 },
-  { color: "f", score: 50 },
-  { color: "e", score: 100 },
-  { color: "a", score: 250 },
-  { color: "d", score: 500 },
-  { color: "b", score: 750 },
-  { color: "c", score: 1000 },
-  { color: "6", score: 1500 },
-  { color: "3", score: 2000 },
-  { color: "a", score: 2500 },
-  { color: "2", score: 3000 },
-  { color: "f", score: 5000 },
-  { color: "9", score: 7500 },
-  { color: "1§l", score: 10_000 },
-  { color: "4", score: 20_000 },
-  { color: "4§l", score: 30_000 },
-  { color: "d§l", score: 40_000 },
-  { color: "0§l", score: 50_000 },
-  { color: "rainbow", score: 100_000 },
-];
 
 export class VampireZ {
   @Field()
@@ -75,20 +31,15 @@ export class VampireZ {
   @Field()
   public zombieKills: number;
 
-  @Field()
+  @Field({
+    leaderboard: { extraDisplay: "stats.vampirez.human.naturalPrefix" },
+  })
   public human: VampireZLife;
 
-  @Field()
+  @Field({
+    leaderboard: { extraDisplay: "stats.vampirez.vampire.naturalPrefix" },
+  })
   public vampire: VampireZLife;
-
-  @Field()
-  public progression: Progression;
-
-  @Field()
-  public currentPrefix: string;
-
-  @Field()
-  public nextPrefix: string;
 
   public constructor(data: APIData, legacy: APIData) {
     this.coins = data.coins;

--- a/packages/schemas/src/player/gamemodes/vampirez/index.ts
+++ b/packages/schemas/src/player/gamemodes/vampirez/index.ts
@@ -6,15 +6,37 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { APIData } from "@statsify/util";
+import { APIData, getFormattedLevel, getPrefixRequirement } from "@statsify/util";
 import { Field } from "../../../metadata";
 import { GameModes, IGameModes } from "../../../game";
+import { Progression } from "../../../progression";
 import { VampireZLife } from "./life";
 import { deepAdd } from "@statsify/math";
 
 export const VAMPIREZ_MODES = new GameModes([{ api: "overall" }]);
-
 export type VampireZModes = IGameModes<typeof VAMPIREZ_MODES>;
+
+const prefixes = [
+  { color: "8", score: 0 },
+  { color: "7", score: 10 },
+  { color: "f", score: 50 },
+  { color: "6", score: 100 },
+  { color: "e", score: 150 },
+  { color: "2", score: 200 },
+  { color: "a", score: 250 },
+  { color: "5", score: 300 },
+  { color: "d", score: 500 },
+  { color: "1", score: 750 },
+  { color: "9§l", score: 1000 },
+  //TODO(@cody): Confirm this is correct
+  { color: "b§l", score: 1500 },
+  { color: "3§l", score: 2000 },
+  //TODO(@cody): Confirm this is correct
+  { color: "b§l", score: 2500 },
+  { color: "c§l", score: 3000 },
+  { color: "4§l", score: 5000 },
+  { color: "8§l", score: 10_000 },
+];
 
 export class VampireZ {
   @Field()
@@ -38,6 +60,15 @@ export class VampireZ {
   @Field()
   public vampire: VampireZLife;
 
+  @Field()
+  public progression: Progression;
+
+  @Field()
+  public currentPrefix: string;
+
+  @Field()
+  public nextPrefix: string;
+
   public constructor(data: APIData, legacy: APIData) {
     this.coins = data.coins;
     this.coins = legacy.vampirez_tokens;
@@ -55,6 +86,15 @@ export class VampireZ {
     VampireZLife.applyRatios(this.human);
 
     this.overall = deepAdd(this.human, this.vampire);
+
+    this.currentPrefix = getFormattedLevel(prefixes, this.overall.wins);
+    this.nextPrefix = getFormattedLevel(prefixes, this.overall.wins, true);
+    this.progression = new Progression(
+      Math.abs(this.overall.wins - getPrefixRequirement(prefixes, this.overall.wins)),
+      getPrefixRequirement(prefixes, this.overall.wins, 1) -
+        getPrefixRequirement(prefixes, this.overall.wins)
+    );
+
     VampireZLife.applyRatios(this.overall);
   }
 }

--- a/packages/schemas/src/player/gamemodes/vampirez/index.ts
+++ b/packages/schemas/src/player/gamemodes/vampirez/index.ts
@@ -6,19 +6,19 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { APIData, getFormattedLevel, getPrefixRequirement } from "@statsify/util";
+import { APIData } from "@statsify/util";
 import { Field } from "../../../metadata";
 import { GameModes, IGameModes } from "../../../game";
 import { Progression } from "../../../progression";
 import { VampireZLife } from "./life";
-import { deepAdd } from "@statsify/math";
+import { add } from "@statsify/math";
 
-export const VAMPIREZ_MODES = new GameModes([{ api: "overall" }]);
+export const VAMPIREZ_MODES = new GameModes([{ api: "human" }, { api: "vampire" }]);
 export type VampireZModes = IGameModes<typeof VAMPIREZ_MODES>;
 
-const prefixes = [
+export const humanPrefixes = [
   { color: "8", score: 0 },
-  { color: "7", score: 10 },
+  { color: "7", score: 20 },
   { color: "f", score: 50 },
   { color: "6", score: 100 },
   { color: "e", score: 150 },
@@ -28,14 +28,35 @@ const prefixes = [
   { color: "d", score: 500 },
   { color: "1", score: 750 },
   { color: "9§l", score: 1000 },
-  //TODO(@cody): Confirm this is correct
   { color: "b§l", score: 1500 },
   { color: "3§l", score: 2000 },
-  //TODO(@cody): Confirm this is correct
   { color: "b§l", score: 2500 },
   { color: "c§l", score: 3000 },
   { color: "4§l", score: 5000 },
-  { color: "8§l", score: 10_000 },
+  { color: "0§l", score: 7500 },
+  { color: "rainbow", score: 15_000 },
+];
+
+export const vampirePrefixes = [
+  { color: "8", score: 0 },
+  { color: "f", score: 50 },
+  { color: "e", score: 100 },
+  { color: "a", score: 250 },
+  { color: "d", score: 500 },
+  { color: "b", score: 750 },
+  { color: "c", score: 1000 },
+  { color: "6", score: 1500 },
+  { color: "3", score: 2000 },
+  { color: "a", score: 2500 },
+  { color: "2", score: 3000 },
+  { color: "f", score: 5000 },
+  { color: "9", score: 7500 },
+  { color: "1§l", score: 10_000 },
+  { color: "4", score: 20_000 },
+  { color: "4§l", score: 30_000 },
+  { color: "d§l", score: 40_000 },
+  { color: "0§l", score: 50_000 },
+  { color: "rainbow", score: 100_000 },
 ];
 
 export class VampireZ {
@@ -46,13 +67,13 @@ export class VampireZ {
   public tokens: number;
 
   @Field()
+  public overallWins: number;
+
+  @Field()
   public mostVampireKills: number;
 
   @Field()
   public zombieKills: number;
-
-  @Field()
-  public overall: VampireZLife;
 
   @Field()
   public human: VampireZLife;
@@ -71,7 +92,8 @@ export class VampireZ {
 
   public constructor(data: APIData, legacy: APIData) {
     this.coins = data.coins;
-    this.coins = legacy.vampirez_tokens;
+    this.tokens = legacy.vampirez_tokens;
+
     this.mostVampireKills = data.most_vampire_kills_new;
     this.zombieKills = data.zombie_kills;
 
@@ -85,17 +107,7 @@ export class VampireZ {
     VampireZLife.applyRatios(this.vampire);
     VampireZLife.applyRatios(this.human);
 
-    this.overall = deepAdd(this.human, this.vampire);
-
-    this.currentPrefix = getFormattedLevel(prefixes, this.overall.wins);
-    this.nextPrefix = getFormattedLevel(prefixes, this.overall.wins, true);
-    this.progression = new Progression(
-      Math.abs(this.overall.wins - getPrefixRequirement(prefixes, this.overall.wins)),
-      getPrefixRequirement(prefixes, this.overall.wins, 1) -
-        getPrefixRequirement(prefixes, this.overall.wins)
-    );
-
-    VampireZLife.applyRatios(this.overall);
+    this.overallWins = add(this.human.wins, this.vampire.wins);
   }
 }
 

--- a/packages/schemas/src/player/gamemodes/vampirez/life.ts
+++ b/packages/schemas/src/player/gamemodes/vampirez/life.ts
@@ -9,7 +9,7 @@
 import { APIData, getFormattedLevel, getPrefixRequirement } from "@statsify/util";
 import { Field } from "../../../metadata";
 import { Progression } from "../../../progression";
-import { humanPrefixes, vampirePrefixes } from "./index";
+import { humanPrefixes, vampirePrefixes } from "./prefixes";
 import { ratio } from "@statsify/math";
 
 export class VampireZLife {
@@ -31,6 +31,16 @@ export class VampireZLife {
   @Field()
   public nextPrefix: string;
 
+  @Field({
+    store: {
+      default: getFormattedLevel({
+        prefixes: humanPrefixes,
+        prefixScore: humanPrefixes[0].score,
+      }),
+    },
+  })
+  public naturalPrefix: string;
+
   @Field()
   public progression: Progression;
 
@@ -42,8 +52,19 @@ export class VampireZLife {
     const prefixes = mode === "human" ? humanPrefixes : vampirePrefixes;
     const stat = mode === "human" ? this.wins : this.kills;
 
-    this.currentPrefix = getFormattedLevel(prefixes, stat);
-    this.nextPrefix = getFormattedLevel(prefixes, stat, true);
+    const prefixScore = this.wins;
+    this.currentPrefix = getFormattedLevel({ prefixes, prefixScore });
+    this.naturalPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      trueScore: true,
+    });
+    this.nextPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      skip: true,
+    });
+
     this.progression = new Progression(
       Math.abs(stat - getPrefixRequirement(prefixes, stat)),
       getPrefixRequirement(prefixes, stat, 1) - getPrefixRequirement(prefixes, stat)

--- a/packages/schemas/src/player/gamemodes/vampirez/life.ts
+++ b/packages/schemas/src/player/gamemodes/vampirez/life.ts
@@ -6,8 +6,10 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { APIData } from "@statsify/util";
+import { APIData, getFormattedLevel, getPrefixRequirement } from "@statsify/util";
 import { Field } from "../../../metadata";
+import { Progression } from "../../../progression";
+import { humanPrefixes, vampirePrefixes } from "./index";
 import { ratio } from "@statsify/math";
 
 export class VampireZLife {
@@ -23,10 +25,29 @@ export class VampireZLife {
   @Field()
   public kdr: number;
 
+  @Field()
+  public currentPrefix: string;
+
+  @Field()
+  public nextPrefix: string;
+
+  @Field()
+  public progression: Progression;
+
   public constructor(data: APIData, mode: string) {
     this.wins = data[`${mode}_wins`];
     this.kills = data[`${mode}_kills`];
     this.deaths = data[`${mode}_deaths`];
+
+    const prefixes = mode === "human" ? humanPrefixes : vampirePrefixes;
+    const stat = mode === "human" ? this.wins : this.kills;
+
+    this.currentPrefix = getFormattedLevel(prefixes, stat);
+    this.nextPrefix = getFormattedLevel(prefixes, stat, true);
+    this.progression = new Progression(
+      Math.abs(stat - getPrefixRequirement(prefixes, stat)),
+      getPrefixRequirement(prefixes, stat, 1) - getPrefixRequirement(prefixes, stat)
+    );
 
     VampireZLife.applyRatios(this);
   }

--- a/packages/schemas/src/player/gamemodes/vampirez/prefixes.ts
+++ b/packages/schemas/src/player/gamemodes/vampirez/prefixes.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Statsify
+ *
+ * This source code is licensed under the GNU GPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ * https://github.com/Statsify/statsify/blob/main/LICENSE
+ */
+
+export const humanPrefixes = [
+  { color: "8", score: 0 },
+  { color: "7", score: 20 },
+  { color: "f", score: 50 },
+  { color: "6", score: 100 },
+  { color: "e", score: 150 },
+  { color: "2", score: 200 },
+  { color: "a", score: 250 },
+  { color: "5", score: 300 },
+  { color: "d", score: 500 },
+  { color: "1", score: 750 },
+  { color: "9§l", score: 1000 },
+  { color: "b§l", score: 1500 },
+  { color: "3§l", score: 2000 },
+  { color: "b§l", score: 2500 },
+  { color: "c§l", score: 3000 },
+  { color: "4§l", score: 5000 },
+  { color: "0§l", score: 7500 },
+  { color: "rainbow", score: 15_000 },
+];
+
+export const vampirePrefixes = [
+  { color: "8", score: 0 },
+  { color: "f", score: 50 },
+  { color: "e", score: 100 },
+  { color: "a", score: 250 },
+  { color: "d", score: 500 },
+  { color: "b", score: 750 },
+  { color: "c", score: 1000 },
+  { color: "6", score: 1500 },
+  { color: "3", score: 2000 },
+  { color: "a", score: 2500 },
+  { color: "2", score: 3000 },
+  { color: "f", score: 5000 },
+  { color: "9", score: 7500 },
+  { color: "1§l", score: 10_000 },
+  { color: "4", score: 20_000 },
+  { color: "4§l", score: 30_000 },
+  { color: "d§l", score: 40_000 },
+  { color: "0§l", score: 50_000 },
+  { color: "rainbow", score: 100_000 },
+];

--- a/packages/schemas/src/player/gamemodes/walls/index.ts
+++ b/packages/schemas/src/player/gamemodes/walls/index.ts
@@ -6,14 +6,31 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { APIData } from "@statsify/util";
+import { APIData, getFormattedLevel, getPrefixRequirement } from "@statsify/util";
 import { Field } from "../../../metadata";
 import { GameModes, IGameModes } from "../../../game";
+import { Progression } from "../../../progression";
 import { ratio } from "@statsify/math";
 
 export const WALLS_MODES = new GameModes([{ api: "overall" }]);
 
 export type WallsModes = IGameModes<typeof WALLS_MODES>;
+
+const prefixes = [
+  { color: "8", score: 0 },
+  { color: "7", score: 25 },
+  { color: "f", score: 50 },
+  { color: "e", score: 100 },
+  { color: "a", score: 200 },
+  { color: "2", score: 300 },
+  { color: "9", score: 400 },
+  { color: "1", score: 500 },
+  { color: "d", score: 750 },
+  { color: "4", score: 1000 },
+  { color: "6", score: 2000 },
+  //TODO(@cody): Make this rainbow
+  { color: "1", score: 2500 },
+];
 
 export class Walls {
   @Field()
@@ -43,6 +60,15 @@ export class Walls {
   @Field()
   public tokens: number;
 
+  @Field()
+  public progression: Progression;
+
+  @Field()
+  public currentPrefix: string;
+
+  @Field()
+  public nextPrefix: string;
+
   public constructor(data: APIData, legacy: APIData) {
     this.coins = data.coins;
     this.wins = data.wins;
@@ -53,5 +79,13 @@ export class Walls {
     this.kdr = ratio(this.kills, this.deaths);
     this.assists = data.assists;
     this.tokens = legacy.walls_tokens;
+
+    this.currentPrefix = getFormattedLevel(prefixes, this.wins);
+    this.nextPrefix = getFormattedLevel(prefixes, this.wins, true);
+    this.progression = new Progression(
+      Math.abs(this.wins - getPrefixRequirement(prefixes, this.wins)),
+      getPrefixRequirement(prefixes, this.wins, 1) -
+        getPrefixRequirement(prefixes, this.wins)
+    );
   }
 }

--- a/packages/schemas/src/player/gamemodes/walls/index.ts
+++ b/packages/schemas/src/player/gamemodes/walls/index.ts
@@ -28,8 +28,7 @@ const prefixes = [
   { color: "d", score: 750 },
   { color: "4", score: 1000 },
   { color: "6", score: 2000 },
-  //TODO(@cody): Make this rainbow
-  { color: "1", score: 2500 },
+  { color: "rainbow", score: 2500 },
 ];
 
 export class Walls {

--- a/packages/schemas/src/player/gamemodes/walls/index.ts
+++ b/packages/schemas/src/player/gamemodes/walls/index.ts
@@ -65,6 +65,11 @@ export class Walls {
   @Field()
   public currentPrefix: string;
 
+  @Field({
+    store: { default: getFormattedLevel({ prefixes, prefixScore: prefixes[0].score }) },
+  })
+  public naturalPrefix: string;
+
   @Field()
   public nextPrefix: string;
 
@@ -79,8 +84,19 @@ export class Walls {
     this.assists = data.assists;
     this.tokens = legacy.walls_tokens;
 
-    this.currentPrefix = getFormattedLevel(prefixes, this.wins);
-    this.nextPrefix = getFormattedLevel(prefixes, this.wins, true);
+    const prefixScore = this.wins;
+    this.currentPrefix = getFormattedLevel({ prefixes, prefixScore });
+    this.naturalPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      trueScore: true,
+    });
+    this.nextPrefix = getFormattedLevel({
+      prefixes,
+      prefixScore,
+      skip: true,
+    });
+
     this.progression = new Progression(
       Math.abs(this.wins - getPrefixRequirement(prefixes, this.wins)),
       getPrefixRequirement(prefixes, this.wins, 1) -

--- a/packages/schemas/src/player/stats.ts
+++ b/packages/schemas/src/player/stats.ts
@@ -38,7 +38,12 @@ export class PlayerStats {
   @Field({ leaderboard: { fieldName: `${FormattedGame.ARCADE} -` } })
   public arcade: Arcade;
 
-  @Field({ leaderboard: { fieldName: FormattedGame.ARENA_BRAWL } })
+  @Field({
+    leaderboard: {
+      fieldName: FormattedGame.ARENA_BRAWL,
+      extraDisplay: "stats.arenabrawl.naturalPrefix",
+    },
+  })
   public arenabrawl: ArenaBrawl;
 
   @Field({
@@ -49,7 +54,12 @@ export class PlayerStats {
   })
   public bedwars: BedWars;
 
-  @Field({ leaderboard: { fieldName: FormattedGame.BLITZSG } })
+  @Field({
+    leaderboard: {
+      fieldName: FormattedGame.BLITZSG,
+      extraDisplay: "stats.blitzsg.naturalPrefix",
+    },
+  })
   public blitzsg: BlitzSG;
 
   @Field({
@@ -78,13 +88,23 @@ export class PlayerStats {
   @Field({ leaderboard: { fieldName: FormattedGame.MURDER_MYSTERY } })
   public murdermystery: MurderMystery;
 
-  @Field({ leaderboard: { fieldName: FormattedGame.PAINTBALL } })
+  @Field({
+    leaderboard: {
+      fieldName: FormattedGame.PAINTBALL,
+      extraDisplay: "stats.paintball.naturalPrefix",
+    },
+  })
   public paintball: Paintball;
 
   @Field({ leaderboard: { fieldName: `${FormattedGame.PARKOUR} -` } })
   public parkour: Parkour;
 
-  @Field({ leaderboard: { fieldName: FormattedGame.QUAKE } })
+  @Field({
+    leaderboard: {
+      fieldName: FormattedGame.QUAKE,
+      extraDisplay: "stats.quake.naturalPrefix",
+    },
+  })
   public quake: Quake;
 
   @Field({
@@ -114,7 +134,12 @@ export class PlayerStats {
   @Field({ leaderboard: { fieldName: FormattedGame.TNT_GAMES } })
   public tntgames: TNTGames;
 
-  @Field({ leaderboard: { fieldName: FormattedGame.TURBO_KART_RACERS } })
+  @Field({
+    leaderboard: {
+      fieldName: FormattedGame.TURBO_KART_RACERS,
+      extraDisplay: "stats.turbokartracers.naturalPrefix",
+    },
+  })
   public turbokartracers: TurboKartRacers;
 
   @Field({
@@ -125,10 +150,19 @@ export class PlayerStats {
   })
   public uhc: UHC;
 
-  @Field({ leaderboard: { fieldName: FormattedGame.VAMPIREZ } })
+  @Field({
+    leaderboard: {
+      fieldName: FormattedGame.VAMPIREZ,
+    },
+  })
   public vampirez: VampireZ;
 
-  @Field({ leaderboard: { fieldName: FormattedGame.WALLS } })
+  @Field({
+    leaderboard: {
+      fieldName: FormattedGame.WALLS,
+      extraDisplay: "stats.walls.naturalPrefix",
+    },
+  })
   public walls: Walls;
 
   @Field({ leaderboard: { fieldName: FormattedGame.WARLORDS } })

--- a/packages/schemas/src/ratios.ts
+++ b/packages/schemas/src/ratios.ts
@@ -16,7 +16,6 @@ export type Ratio = [
 
 export const LEADERBOARD_RATIOS: Ratio[] = [
   ["wins", "losses", "wlr", "WLR"],
-  ["kills", "wins", "kwr", "KWR"],
   ["kills", "deaths", "kdr", "KDR"],
   ["finalKills", "finalDeaths", "fkdr", "FKDR"],
   ["bedsBroken", "bedsLost", "bblr", "BBLR"],
@@ -27,6 +26,7 @@ export const LEADERBOARD_RATIO_KEYS = LEADERBOARD_RATIOS.map(
 );
 
 const EXTRA_RATIOS: Ratio[] = [
+  ["kills", "wins", "kwr", "KWR"],
   ["kills", "shotsFired", "shotAccuracy", "Shot Accuracy", 100],
   ["postUpdateKills", "shotsFired", "quakeShotAccuracy", "Shot Accuracy", 100],
   ["gold", "gamesPlayed", "goldRate", "Gold Rate", 100],

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -61,6 +61,14 @@ export const getPrefixRequirement = (
     : prefixes[Math.min(prefixIndex + skip - 1, prefixes.length - 1)].score || 0;
 };
 
+export interface FormatProgressionOptions {
+  prefixes: { color: string; score: number }[];
+  prefixScore: number;
+  skip?: boolean;
+  titleSuffix?: string;
+
+  trueScore?: boolean;
+}
 /**
  *
  * @param prefixes An array of objects with a color code and req property
@@ -69,31 +77,29 @@ export const getPrefixRequirement = (
  * @parm titleSuffix The suffix to append to the title, for example a star
  * @returns The formatted prefix
  */
-export const getFormattedLevel = (
-  prefixes: { color: string; score: number }[],
-  score: number,
-  skip?: boolean,
-  titleSuffix?: string
-): string => {
-  //TODO(@cody): Add support for rainbow colors
+export const getFormattedLevel = ({
+  prefixes,
+  prefixScore,
+  skip = false,
+  titleSuffix = "",
+  trueScore = false,
+}: FormatProgressionOptions) => {
   const prefixColors: { req: number; fn: (n: number) => string }[] = prefixes.map(
     (prefix) => ({
       req: prefix.score,
       fn: (n) => {
-        const [number, suffix] = abbreviationNumber(n);
+        const [number, suffix] = abbreviationNumber(trueScore ? prefixScore : n);
 
         if (prefix.color === "rainbow") {
-          return `${formatRainbow(
-            `[${Math.floor(number)}${suffix}${titleSuffix ?? ""}]`
-          )}`;
+          return `${formatRainbow(`[${Math.floor(number)}${suffix}${titleSuffix}]`)}`;
         }
 
-        return `§${prefix.color}[${Math.floor(number)}${suffix}${titleSuffix ?? ""}]`;
+        return `§${prefix.color}[${Math.floor(number)}${suffix}${titleSuffix}]`;
       },
     })
   );
 
-  const scores = findScore(prefixColors, score);
+  const scores = findScore(prefixColors, prefixScore);
 
   const prefixIndex = prefixes.findIndex((score) => score.score === scores.req);
 
@@ -101,7 +107,9 @@ export const getFormattedLevel = (
 
   return skip
     ? findScore(prefixColors, nextScore).fn(nextScore)
-    : scores.fn(score > prefixes.at(-1)!.score ? score : prefixes[prefixIndex].score);
+    : scores.fn(
+        prefixScore > prefixes.at(-1)!.score ? prefixScore : prefixes[prefixIndex].score
+      );
 };
 
 const rainbowColors = ["c", "6", "e", "a", "b", "9", "d"];

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -52,11 +52,13 @@ export const getPrefixRequirement = (
   score: number,
   skip = 0
 ): number => {
-  const prefixIndex = prefixes.findIndex((requirement) => requirement.score > score);
+  const prefixIndex = prefixes.findIndex(
+    (requirement) => requirement.score > (score || 0)
+  );
 
   return prefixIndex === -1
     ? prefixes.at(-1)!.score
-    : prefixes[Math.min(prefixIndex + skip - 1, prefixes.length - 1)].score;
+    : prefixes[Math.min(prefixIndex + skip - 1, prefixes.length - 1)].score || 0;
 };
 
 /**
@@ -64,12 +66,14 @@ export const getPrefixRequirement = (
  * @param prefixes An array of objects with a color code and req property
  * @param score The value to compare against
  * @param skip Whether to skip the next prefix
+ * @parm titleSuffix The suffix to append to the title, for example a star
  * @returns The formatted prefix
  */
 export const getFormattedLevel = (
   prefixes: { color: string; score: number }[],
   score: number,
-  skip?: boolean
+  skip?: boolean,
+  titleSuffix?: string
 ): string => {
   //TODO(@cody): Add support for rainbow colors
   const prefixColors: { req: number; fn: (n: number) => string }[] = prefixes.map(
@@ -78,7 +82,7 @@ export const getFormattedLevel = (
       fn: (n) => {
         const [number, suffix] = abbreviationNumber(n);
 
-        return `§${prefix.color}[${number}${suffix}]`;
+        return `§${prefix.color}[${number}${suffix}${titleSuffix ?? ""}]`;
       },
     })
   );

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -82,7 +82,13 @@ export const getFormattedLevel = (
       fn: (n) => {
         const [number, suffix] = abbreviationNumber(n);
 
-        return `§${prefix.color}[${number}${suffix}${titleSuffix ?? ""}]`;
+        if (prefix.color === "rainbow") {
+          return `${formatRainbow(
+            `[${Math.floor(number)}${suffix}${titleSuffix ?? ""}]`
+          )}`;
+        }
+
+        return `§${prefix.color}[${Math.floor(number)}${suffix}${titleSuffix ?? ""}]`;
       },
     })
   );
@@ -97,6 +103,11 @@ export const getFormattedLevel = (
     ? findScore(prefixColors, nextScore).fn(nextScore)
     : scores.fn(score > prefixes.at(-1)!.score ? score : prefixes[prefixIndex].score);
 };
+
+const rainbowColors = ["c", "6", "e", "a", "b", "9", "d"];
+
+export const formatRainbow = (text: string) =>
+  [...text].map((l, i) => `§${rainbowColors[i % rainbowColors.length]}${l}`).join("");
 
 /**
  *


### PR DESCRIPTION
Description:  
- Adds the classic game chat prefixes to all 6 games (AB, VZ, TKR, Q, W, PB). 
- Includes an infection win fix and 
- Fixes rounding of 0 and numbers <1000.

Some showcase:
![image](https://user-images.githubusercontent.com/36463298/179900293-0c91a87f-2615-442d-b931-f7dbcb4ba8e9.png)
e:
![image](https://user-images.githubusercontent.com/36463298/179900299-4124f95f-7a5b-4d36-8afe-25f4bfdf4bfb.png)
![image](https://user-images.githubusercontent.com/36463298/179900304-59f229b0-90da-4e60-9782-376391570a7c.png)
![image](https://user-images.githubusercontent.com/36463298/179900316-c2f42d70-2fe2-4bd6-9ffb-a5c0fc417d94.png)
![image](https://user-images.githubusercontent.com/36463298/179900327-1f49ef97-ef13-4017-9df4-f41c0527432f.png)

obv. is better to run the bot and see live instead of these but better than nothing.


