### PR TITLE
fix(pit): Added correct prestige color to p45-49.

### DIFF
--- a/packages/schemas/src/player/gamemodes/pit/util.ts
+++ b/packages/schemas/src/player/gamemodes/pit/util.ts
@@ -28,7 +28,7 @@ const presXpReq = [
   11_787_293_080,
 ];
 
-const prestigecolors = ["7", "9", "e", "6", "c", "5", "d", "f", "b", "1", "2", "3"];
+const prestigecolors = ["7", "9", "e", "6", "c", "5", "d", "f", "b", "1", "0", "3"];
 
 const levelColors = [
   "7",


### PR DESCRIPTION
Description: Replaces current green brackets (placeholder) with black brackets (the actual in-game color).

![image](https://user-images.githubusercontent.com/96643991/189535443-371515bf-fe0f-479a-94af-ae9520a3f894.png)
![image](https://user-images.githubusercontent.com/96643991/189535449-703a2f12-2217-4b42-955e-6f7f180b78a8.png)
