### PR TITLE
fix(uhc): submodes stats not counting

### DIFF
--- a/packages/schemas/src/player/gamemodes/uhc/index.ts
+++ b/packages/schemas/src/player/gamemodes/uhc/index.ts
@@ -85,11 +85,11 @@ export class UHC {
     this.overall = deepAdd(
       this.solo,
       this.teams,
-      new UHCMode(data, "no diamonds"),
-      new UHCMode(data, "vanilla doubles"),
+      new UHCMode(data, "no_diamonds"),
+      new UHCMode(data, "vanilla_doubles"),
       new UHCMode(data, "brawl"),
-      new UHCMode(data, "solo brawl"),
-      new UHCMode(data, "duo brawl")
+      new UHCMode(data, "solo_brawl"),
+      new UHCMode(data, "duo_brawl")
     );
 
     UHCMode.applyRatios(this.overall);


### PR DESCRIPTION
- Hypixel made the UHC submodes have underscores in their key names so the stats weren't counting