### PR TITLE
fix(capes): remove blank whitespace at the bottom of cape images

### DIFF
--- a/apps/discord-bot/src/commands/minecraft/cape.command.ts
+++ b/apps/discord-bot/src/commands/minecraft/cape.command.ts
@@ -112,7 +112,7 @@ export class CapeCommand {
       }
     }
 
-    const ratio = Math.min(canvas.width / width, canvas.height / height);
+    const ratio = Math.round(Math.min(canvas.width / width, canvas.height / height));
 
     ctx.drawImage(
       cape,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42344274/200635184-46c83c93-aa64-489b-ac78-0d8c097c70c8.png)
