### PR TITLE
fix: rounding of prefixes that aren't multiples of 10

### DIFF
--- a/apps/discord-bot/src/commands/megawalls/megawalls.command.tsx
+++ b/apps/discord-bot/src/commands/megawalls/megawalls.command.tsx
@@ -12,38 +12,13 @@ import {
   ProfileData,
 } from "../base.hypixel-command";
 import { Command } from "@statsify/discord";
-import {
-  GameMode,
-  MEGAWALLS_MODES,
-  MegaWallsKit,
-  MegaWallsModes,
-  Player,
-} from "@statsify/schemas";
+import { MEGAWALLS_MODES, MegaWallsModes } from "@statsify/schemas";
 import { MegaWallsProfile } from "./megawalls.profile";
 
 @Command({ description: (t) => t("commands.megawalls") })
 export class MegaWallsCommand extends BaseHypixelCommand<MegaWallsModes> {
   public constructor() {
     super(MEGAWALLS_MODES);
-  }
-
-  public filterModes(
-    player: Player,
-    modes: GameMode<MegaWallsModes>[]
-  ): GameMode<MegaWallsModes>[] {
-    const { megawalls } = player.stats;
-    const [overall, ...kits] = modes;
-
-    const filteredKits = kits
-      .slice(1, -1)
-      .sort(
-        (a, b) =>
-          (megawalls[b.api] as MegaWallsKit).points -
-          (megawalls[a.api] as MegaWallsKit).points
-      )
-      .slice(0, 24);
-
-    return [overall, ...filteredKits];
   }
 
   public getProfile(

--- a/packages/schemas/src/player/gamemodes/prefixes.ts
+++ b/packages/schemas/src/player/gamemodes/prefixes.ts
@@ -102,9 +102,20 @@ export const getFormattedPrefix = <T extends unknown[] = []>({
   if (!abbreviation)
     return prefix.fmt(`${trueScore ? Math.floor(score) : prefix.req}`, ...prefixParams);
 
-  const [number, suffix] = abbreviationNumber(trueScore ? score : prefix.req);
-  const formattedScore = trueScore ? Math.floor(number) : number;
-  return prefix.fmt(`${formattedScore}${suffix}`, ...prefixParams);
+  const [prefixNumber, prefixSuffix] = abbreviationNumber(prefix.req);
+
+  if (!trueScore) return prefix.fmt(`${prefixNumber}${prefixSuffix}`, ...prefixParams);
+
+  let [number, suffix] = abbreviationNumber(score);
+
+  number = Math.floor(number);
+
+  if (number < prefixNumber) {
+    number = prefixNumber;
+    suffix = prefixSuffix;
+  }
+
+  return prefix.fmt(`${number}${suffix}`, ...prefixParams);
 };
 
 export const defaultPrefix = <T extends unknown[] = []>(


### PR DESCRIPTION
- Correctly rounds prefixes if there is a prefix that is not a multiple of 10
- Fixes missing mega walls kit in dropdown
Old
![image](https://user-images.githubusercontent.com/42344274/220208290-c79dab30-12e7-4cac-978c-6f52ec84efee.png)
New
![image](https://user-images.githubusercontent.com/42344274/220208271-ff17943b-712a-47f8-9776-f3b1ce3fffd2.png)