### PR TITLE
fix(woolwars): remove extra characters from prestige icons

### DIFF
--- a/packages/schemas/src/player/gamemodes/woolwars/util.ts
+++ b/packages/schemas/src/player/gamemodes/woolwars/util.ts
@@ -44,10 +44,10 @@ export const getLevel = (exp = 0): number => {
 */
 
 const PRESTIGE_COLORS: { req: number; format: (level: number) => string }[] = [
-  { req: 0, format: (l) => `§7[${l}❤️]` },
+  { req: 0, format: (l) => `§7[${l}❤]` },
   { req: 100, format: (l) => `§f[${l}✙]` },
   { req: 200, format: (l) => `§c[${l}✫]` },
-  { req: 300, format: (l) => `§6[${l}✈︎]` },
+  { req: 300, format: (l) => `§6[${l}✈]` },
   { req: 400, format: (l) => `§e[${l}✠]` },
   { req: 500, format: (l) => `§a[${l}♕]` },
   { req: 600, format: (l) => `§3[${l}⚡]` },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42344274/230713812-d83a84f1-54cc-42d9-b895-0152572db918.png)
Fixes the extra Unicode characters as seen in the image. 