### PR TITLE
fix(config): make config commands use proper localization string

### DIFF
--- a/apps/discord-bot/src/commands/config/badge.command.tsx
+++ b/apps/discord-bot/src/commands/config/badge.command.tsx
@@ -159,7 +159,7 @@ export class BadgeCommand {
         skin={skin}
         badge={badge}
         user={user}
-        message={t("config.badge.profile.js")}
+        message={t("config.badge.profile")}
       />,
       getTheme(user)
     );

--- a/apps/discord-bot/src/commands/config/theme.command.tsx
+++ b/apps/discord-bot/src/commands/config/theme.command.tsx
@@ -238,7 +238,7 @@ export class ThemeCommand {
         badge={badge}
         user={user}
         message={
-          mode === "theme" ? t("config.theme.profile.js") : t("config.footer.profile.js")
+          mode === "theme" ? t("config.theme.profile") : t("config.footer.profile")
         }
       />,
       getTheme(user)


### PR DESCRIPTION
![image](https://github.com/Statsify/statsify/assets/42344274/2977edcf-38e2-4fcf-8030-e600df398cbb)
- Prevents this ^