### PR TITLE
feat: rename coins -> tokens and remove loot chests

### DIFF
--- a/apps/discord-bot/src/commands/bedwars/bedwars.profile.tsx
+++ b/apps/discord-bot/src/commands/bedwars/bedwars.profile.tsx
@@ -37,8 +37,7 @@ export const BedWarsProfile = ({
   const stats = bedwars[mode.api];
 
   const sidebar: SidebarItem[] = [
-    [t("stats.coins"), t(bedwars.coins), "§6"],
-    [t("stats.lootChests"), t(bedwars.lootChests), "§e"],
+    [t("stats.tokens"), t(bedwars.tokens), "§2"],
     [t("stats.iron"), t(stats.itemsCollected.iron), "§7"],
     [t("stats.gold"), t(stats.itemsCollected.gold), "§6"],
     [t("stats.diamonds"), t(stats.itemsCollected.diamond), "§b"],

--- a/apps/discord-bot/src/commands/duels/bridge.profile.tsx
+++ b/apps/discord-bot/src/commands/duels/bridge.profile.tsx
@@ -38,7 +38,7 @@ export const BridgeProfile = ({
   const stats = bridge[mode.api];
 
   const sidebar: SidebarItem[] = [
-    [t("stats.pingRange"), `${t(duels.pingRange)}ms`, "§2"],
+    [t("stats.pingRange"), `${t(duels.pingRange)}ms`, "§a"],
     [t("stats.goals"), t(stats.goals), "§c"],
     [t("stats.blocksPlaced"), t(stats.blocksPlaced), "§9"],
   ];

--- a/apps/discord-bot/src/commands/duels/duels.profile.tsx
+++ b/apps/discord-bot/src/commands/duels/duels.profile.tsx
@@ -34,9 +34,8 @@ export const DuelsProfile = ({
   const { duels } = player.stats;
 
   const sidebar: SidebarItem[] = [
-    [t("stats.coins"), t(duels.coins), "§6"],
-    [t("stats.lootChests"), t(duels.lootChests), "§e"],
-    [t("stats.pingRange"), `${t(duels.pingRange)}ms`, "§2"],
+    [t("stats.tokens"), t(duels.tokens), "§2"],
+    [t("stats.pingRange"), `${t(duels.pingRange)}ms`, "§a"],
     [t("stats.blocksPlaced"), t(duels.overall.blocksPlaced), "§9"],
   ];
 

--- a/apps/discord-bot/src/commands/murdermystery/murdermystery.profile.tsx
+++ b/apps/discord-bot/src/commands/murdermystery/murdermystery.profile.tsx
@@ -29,8 +29,7 @@ export const MurderMysteryProfile = ({
   const { murdermystery } = player.stats;
 
   const sidebar: SidebarItem[] = [
-    [t("stats.coins"), t(murdermystery.coins), "§6"],
-    [t("stats.lootChests"), t(murdermystery.lootChests), "§e"],
+    [t("stats.tokens"), t(murdermystery.tokens), "§2"],
     [t("stats.goldPickedUp"), t(murdermystery[mode.api].goldPickedUp), "§6"],
     [t("stats.gamesPlayed"), t(murdermystery[mode.api].gamesPlayed), "§b"],
   ];

--- a/apps/discord-bot/src/commands/skywars/skywars.profile.tsx
+++ b/apps/discord-bot/src/commands/skywars/skywars.profile.tsx
@@ -39,7 +39,6 @@ export const SkyWarsProfile = ({
 
   const sidebar: SidebarItem[] = [
     [t("stats.coins"), t(skywars.coins), "§6"],
-    [t("stats.lootChests"), t(skywars.lootChests), "§e"],
     [t("stats.tokens"), t(skywars.tokens), "§2"],
     [t("stats.souls"), t(skywars.souls), "§b"],
     [t("stats.opals"), t(skywars.opals), "§9"],

--- a/packages/schemas/src/player/gamemodes/bedwars/index.ts
+++ b/packages/schemas/src/player/gamemodes/bedwars/index.ts
@@ -157,15 +157,6 @@ export class BedWars {
 
     this.progression = new Progression(exp, getExpReq(Math.floor(this.level)));
 
-    this.lootChests = add(
-      data.bedwars_boxes,
-      data.bedwars_christmas_boxes,
-      data.bedwars_halloween_boxes,
-      data.bedwars_lunar_boxes,
-      data.bedwars_golden_boxes,
-      data.bedwars_easter_boxes
-    );
-
     this.overall = new BedWarsMode(data, "");
     this.solo = new BedWarsMode(data, "eight_one");
     this.doubles = new BedWarsMode(data, "eight_two");

--- a/packages/schemas/src/player/gamemodes/bedwars/index.ts
+++ b/packages/schemas/src/player/gamemodes/bedwars/index.ts
@@ -53,10 +53,7 @@ export type BedWarsModes = IGameModes<typeof BEDWARS_MODES>;
 
 export class BedWars {
   @Field({ historical: { enabled: false } })
-  public coins: number;
-
-  @Field({ historical: { enabled: false } })
-  public lootChests: number;
+  public tokens: number;
 
   @Field({
     leaderboard: {
@@ -145,7 +142,7 @@ export class BedWars {
   public slumber: Slumber;
 
   public constructor(data: APIData = {}) {
-    this.coins = data.coins;
+    this.tokens = data.coins;
 
     this.exp = data.Experience || 0;
     this.level = getLevel(this.exp);

--- a/packages/schemas/src/player/gamemodes/duels/index.ts
+++ b/packages/schemas/src/player/gamemodes/duels/index.ts
@@ -77,13 +77,7 @@ export class Duels {
     leaderboard: { extraDisplay: "this.overall.titleFormatted" },
     historical: { enabled: false },
   })
-  public coins: number;
-
-  @Field({
-    leaderboard: { extraDisplay: "this.overall.titleFormatted" },
-    historical: { enabled: false },
-  })
-  public lootChests: number;
+  public tokens: number;
 
   @Field({ leaderboard: { extraDisplay: "this.overall.titleFormatted" } })
   public overall: SinglePVPDuelsGameMode;
@@ -179,8 +173,7 @@ export class Duels {
     this.uhc = new UHCDuels(data);
 
     this.pingRange = data?.pingPreference ?? 300;
-    this.coins = data.coins;
-    this.lootChests = data.duels_chests;
+    this.tokens = data.coins;
   }
 }
 

--- a/packages/schemas/src/player/gamemodes/murdermystery/index.ts
+++ b/packages/schemas/src/player/gamemodes/murdermystery/index.ts
@@ -14,7 +14,6 @@ import {
 } from "./mode.js";
 import { Field } from "#metadata";
 import { GameModes, type IGameModes } from "#game";
-import { add } from "@statsify/math";
 import type { APIData } from "@statsify/util";
 
 export const MURDER_MYSTERY_MODES = new GameModes([
@@ -34,10 +33,7 @@ export type MurderMysteryModes = IGameModes<typeof MURDER_MYSTERY_MODES>;
 
 export class MurderMystery {
   @Field({ historical: { enabled: false } })
-  public coins: number;
-
-  @Field({ historical: { enabled: false } })
-  public lootChests: number;
+  public tokens: number;
 
   @Field()
   public overall: StandardMurderMysteryMode;
@@ -55,16 +51,7 @@ export class MurderMystery {
   public infection: InfectionMurderMysteryMode;
 
   public constructor(data: APIData, ap: APIData) {
-    this.coins = data.coins;
-
-    this.lootChests = add(
-      data.mm_chests,
-      data.mm_easter_chests,
-      data.mm_christmas_chests,
-      data.mm_halloween_chests,
-      data.mm_lunar_chests,
-      data.mm_golden_chests
-    );
+    this.tokens = data.coins;
 
     this.overall = new StandardMurderMysteryMode(data, "");
     this.classic = new ClassicMurderMysteryMode(data, "MURDER_CLASSIC");

--- a/packages/schemas/src/player/gamemodes/skywars/index.ts
+++ b/packages/schemas/src/player/gamemodes/skywars/index.ts
@@ -78,9 +78,6 @@ export class SkyWars {
   @Field()
   public potionsBrewed: number;
 
-  @Field({ historical: { enabled: false } })
-  public lootChests: number;
-
   @Field({ store: { default: "⋆" } })
   public star: string;
 
@@ -116,15 +113,6 @@ export class SkyWars {
     this.heads = data.heads;
     this.tokens = data.cosmetic_tokens;
     this.potionsBrewed = ap.skywars_tonic_taker;
-
-    this.lootChests = add(
-      data.skywars_chests,
-      data.skywars_easter_boxes,
-      data.skywars_halloween_boxes,
-      data.skywars_christmas_boxes,
-      data.skywars_lunar_boxes,
-      data.skywars_golden_boxes
-    );
 
     this.star = (data.levelFormatted || "⋆").replace(/\d|[a-f]|k|r|l|§/g, "");
     this.level = getLevel(this.exp);

--- a/packages/skin-renderer/Cargo.toml
+++ b/packages/skin-renderer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name    = "statsify-skin-renderer"
+name = "statsify-skin-renderer"
 authors = ["Jacob Koshy <jababakoshy@gmail.com>"]
 edition = "2021"
 version = "0.1.0"
@@ -10,8 +10,8 @@ version = "0.1.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = { version = "2.13.3", features = ["async"] }
-napi-derive = "2.13.0"
+napi = { version = "2.15.0", features = ["async"] }
+napi-derive = "2.15.0"
 bytemuck = { version = "1.13.1", features = ["derive"] }
 cgmath = "0.18.0"
 futures-intrusive = "0.5.0"


### PR DESCRIPTION
![image](https://github.com/Statsify/statsify/assets/42344274/91f09a1e-e977-4d17-9d9c-8a0b9a5e96e4)
- Completely remove loot chests
- Rename coins to tokens for Bed Wars, Duels, and Murder Mystery