### PR TITLE
fix(leaderboards): remove wiped players from leaderboards

### DIFF
--- a/apps/api/src/leaderboards/leaderboard.service.ts
+++ b/apps/api/src/leaderboards/leaderboard.service.ts
@@ -54,7 +54,7 @@ export abstract class LeaderboardService {
       const value = instance[field] as unknown as number;
       const key = `${name}.${String(field)}`;
 
-      if (remove || value === 0 || Number.isNaN(value)) {
+      if (remove || value === 0 || Number.isNaN(value) || typeof value !== "number") {
         pipeline.zrem(key, id);
         continue;
       }

--- a/apps/discord-bot/src/commands/leaderboards/guild-leaderboard.argument.ts
+++ b/apps/discord-bot/src/commands/leaderboards/guild-leaderboard.argument.ts
@@ -15,7 +15,7 @@ import { Fuse } from "fuse.js";
 import { Guild, LeaderboardScanner } from "@statsify/schemas";
 import { removeFormatting } from "@statsify/util";
 
-const list = LeaderboardScanner.getLeaderboardMetadata(Guild).map(
+const list = LeaderboardScanner.getLeaderboardFields(Guild).map(
   ([key, { leaderboard }]) => ({
     value: key,
     name: removeFormatting(leaderboard.name),

--- a/apps/discord-bot/src/commands/leaderboards/player-leaderboard.argument.ts
+++ b/apps/discord-bot/src/commands/leaderboards/player-leaderboard.argument.ts
@@ -34,7 +34,7 @@ const FUSE_OPTIONS = {
 };
 
 const fields = entries.reduce((acc, [prefix, value]) => {
-  const list = LeaderboardScanner.getLeaderboardMetadata(value.type.type).map(
+  const list = LeaderboardScanner.getLeaderboardFields(value.type.type).map(
     ([key, { leaderboard }]) => ({ value: key, name: removeFormatting(leaderboard.name) })
   );
 

--- a/packages/schemas/src/util/leaderboard-scanner.ts
+++ b/packages/schemas/src/util/leaderboard-scanner.ts
@@ -15,16 +15,12 @@ import { parseAdditionalFields } from "./parse-fields.js";
 import type { Constructor } from "@statsify/util";
 
 export class LeaderboardScanner {
-  public static getLeaderboardMetadata<T>(constructor: Constructor<T>) {
+  public static getLeaderboardFields<T>(constructor: Constructor<T>) {
     const metadata = MetadataScanner.scan(constructor);
 
     const fields = metadata.filter(([, { leaderboard }]) => leaderboard.enabled);
 
     return fields;
-  }
-
-  public static getLeaderboardFields<T>(constructor: Constructor<T>) {
-    return this.getLeaderboardMetadata(constructor);
   }
 
   public static getLeaderboardField<T>(


### PR DESCRIPTION
Currently, if a player is wiped and their stats reset to 0, they won't be removed from leaderboards. This fixes that.
![image](https://github.com/Statsify/statsify/assets/42344274/98707445-7321-426a-95fa-5a3e2fda4c04)
