### PR TITLE
fix(disocrd-bot): dashed uuid format in /uuid

### DIFF
--- a/apps/discord-bot/src/commands/minecraft/uuid.command.ts
+++ b/apps/discord-bot/src/commands/minecraft/uuid.command.ts
@@ -23,19 +23,19 @@ export class UUIDCommand {
   public async run(context: CommandContext) {
     const user = context.getUser();
 
-    const player = await this.apiService.getPlayerSkinTextures(
+    const { username, uuid } = await this.apiService.getPlayerSkinTextures(
       context.option<string>("player"),
       user
     );
 
-    const thumbURL = minecraftHeadUrl(player.uuid);
-
+    const dashedUuid = `${uuid.slice(0, 8)}-${uuid.slice(8, 12)}-${uuid.slice(12, 16)}-${uuid.slice(16, 20)}-${uuid.slice(20)}`;
+    
     const embed = new EmbedBuilder()
-      .field((t) => t("minecraft.username"), `\`${player.username}\``)
-      .field((t) => t("minecraft.uuid"), `\`${player.uuid}\``)
-      .field((t) => t("minecraft.trimmedUUID"), `\`${player.uuid.replaceAll("-", "")}\``)
+      .field((t) => t("minecraft.username"), `\`${username}\``)
+      .field((t) => t("minecraft.uuid"), `\`${dashedUuid}\``)
+      .field((t) => t("minecraft.trimmedUUID"), `\`${uuid}\``)
       .color(STATUS_COLORS.info)
-      .thumbnail(thumbURL);
+      .thumbnail(minecraftHeadUrl(uuid));
 
     return { embeds: [embed] };
   }


### PR DESCRIPTION
Currently both uuids in `/uuid` have no dashes. This fixes that.
![image](https://github.com/Statsify/statsify/assets/42344274/d7e423cd-220a-48d1-8ad5-33ed04a96364)
