### PR TITLE
fix(discord-bot): show latest event's exp in session general stats

### DIFF
--- a/apps/discord-bot/src/commands/events/event-colors.ts
+++ b/apps/discord-bot/src/commands/events/event-colors.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Statsify
+ *
+ * This source code is licensed under the GNU GPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ * https://github.com/Statsify/statsify/blob/main/LICENSE
+ */
+
+import type { EventPeriod } from "@statsify/schemas";
+
+export const EVENT_COLORS: Record<EventPeriod, string> = {
+  summer: "§e",
+  halloween: "§5",
+  christmas: "§c",
+  easter: "§b",
+};

--- a/apps/discord-bot/src/commands/events/events.profile.tsx
+++ b/apps/discord-bot/src/commands/events/events.profile.tsx
@@ -16,31 +16,22 @@ import {
   formatProgression,
   lineXpBar,
 } from "#components";
+import { EVENT_COLORS } from "./event-colors.js";
 import { arrayGroup, prettify } from "@statsify/util";
 import type { BaseProfileProps } from "#commands/base.hypixel-command";
-import type { Event, EventPeriods, EventTypes } from "@statsify/schemas";
+import type { Event, EventPeriod, EventType } from "@statsify/schemas";
 import type { LocalizeFunction } from "@statsify/discord";
 
 interface EventTableProps {
-  type: EventTypes;
+  type: EventType;
   event: Event;
   t: LocalizeFunction;
 }
 
-const EVENT_COLORS: Record<EventPeriods, string> = {
-  summer: "§e",
-  halloween: "§5",
-  christmas: "§c",
-  easter: "§b",
-};
-
 const EventTable = ({ type, event, t }: EventTableProps) => {
-  const yearIndex = type.indexOf("20");
-  const year = type.slice(yearIndex, yearIndex + 4);
-  const period = type.slice(0, yearIndex);
-
+  const { period, year } = type;
   const title = `${prettify(period)} ${year}`;
-  const color = EVENT_COLORS[period as EventPeriods];
+  const color = EVENT_COLORS[period as EventPeriod];
 
   const levelling = [
     `§7${t("stats.event-level")}: ${color}${t(Math.floor(event.level))}`,
@@ -65,7 +56,7 @@ const EventTable = ({ type, event, t }: EventTableProps) => {
 };
 
 interface EventsProfileProps extends Omit<BaseProfileProps, "time"> {
-  eventNames: EventTypes[];
+  eventNames: EventType[];
 }
 
 export const EventsProfile = ({
@@ -96,7 +87,7 @@ export const EventsProfile = ({
         {arrayGroup(eventNames, 2).map((eventTypes) => (
           <Table.tr>
             {eventTypes.map((type) => (
-              <EventTable type={type} event={events[type]} t={t} />
+              <EventTable type={type} event={events[type.key]} t={t} />
             ))}
           </Table.tr>
         ))}

--- a/apps/discord-bot/src/commands/general/historical-general.profile.tsx
+++ b/apps/discord-bot/src/commands/general/historical-general.profile.tsx
@@ -7,8 +7,12 @@
  */
 
 import { Container, Footer, Header, Table } from "#components";
-import { FormattedGame } from "@statsify/schemas";
+import { EVENT_COLORS } from "#commands/events/event-colors";
+import { EVENT_TYPES, FormattedGame } from "@statsify/schemas";
 import type { BaseProfileProps } from "#commands/base.hypixel-command";
+
+const latestEvent = EVENT_TYPES[0];
+const latestEventColor = EVENT_COLORS[latestEvent.period];
 
 export const HistoricalGeneralProfile = ({
   background,
@@ -45,8 +49,8 @@ export const HistoricalGeneralProfile = ({
           />
           <Table.td
             title={t("stats.event-exp")}
-            value={t(general.events.christmas2022.exp)}
-            color="§c"
+            value={t(general.events[latestEvent.key].exp)}
+            color={latestEventColor}
           />
         </Table.tr>
         <Table.tr>

--- a/packages/schemas/src/player/gamemodes/general/events.ts
+++ b/packages/schemas/src/player/gamemodes/general/events.ts
@@ -33,21 +33,21 @@ export class Event {
   }
 }
 
-export type EventTypes = Exclude<keyof Events, "silver">;
-export type EventPeriods = "summer" | "halloween" | "christmas" | "easter";
+export type EventType = { period: EventPeriod; year: number; key: Exclude<keyof Events, "silver"> };
+export type EventPeriod = "summer" | "halloween" | "christmas" | "easter";
 
-export const EVENT_TYPES: EventTypes[] = [
-  "christmas2024",
-  "halloween2024",
-  "summer2024",
-  "easter2024",
-  "christmas2023",
-  "halloween2023",
-  "summer2023",
-  "easter2023",
-  "christmas2022",
-  "halloween2022",
-  "summer2022",
+export const EVENT_TYPES: EventType[] = [
+  { period: "christmas", year: 2024, key: "christmas2024" },
+  { period: "halloween", year: 2024, key: "halloween2024" },
+  { period: "summer", year: 2024, key: "summer2024" },
+  { period: "easter", year: 2024, key: "easter2024" },
+  { period: "christmas", year: 2023, key: "christmas2023" },
+  { period: "halloween", year: 2023, key: "halloween2023" },
+  { period: "summer", year: 2023, key: "summer2023" },
+  { period: "easter", year: 2023, key: "easter2023" },
+  { period: "christmas", year: 2022, key: "christmas2022" },
+  { period: "halloween", year: 2022, key: "halloween2022" },
+  { period: "summer", year: 2022, key: "summer2022" },
 ];
 
 export class Events {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3363b7fb-fc19-4889-bdfa-7a942201cee9)
![image](https://github.com/user-attachments/assets/84a27737-7f69-40d6-a9ea-9a9fd5893efd)
