### PR TITLE
fix(discord-bot): incorrect width unicode underline and strikethroughs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ apps/support-bot/commands.json
 Cargo.lock
 /target
 *.node
+.env

--- a/apps/discord-bot/src/commands/minecraft/text.command.tsx
+++ b/apps/discord-bot/src/commands/minecraft/text.command.tsx
@@ -42,7 +42,7 @@ export class TextCommand {
     const text = convertColorCodes(content).replaceAll(String.raw`\n`, "\n");
 
     const canvas = render(
-      <div direction="column">
+      <div direction="column" padding={2}>
         <Multiline size={size} align={alignment}>
           {text}
         </Multiline>

--- a/apps/site/next-env.d.ts
+++ b/apps/site/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/rendering/src/font/font-renderer.ts
+++ b/packages/rendering/src/font/font-renderer.ts
@@ -267,27 +267,24 @@ export class FontRenderer {
     const { x: charX, y: charY, width, height, scale, isAscii, image, size } = metadata;
 
     const imageData = image.getImageData(charX, charY, width, height);
-    const resizeFactor = size * scale;
-
-    const offset = isAscii ? 2 : 1;
 
     ctx.filter = "brightness(25%)";
 
     this.fillFormattedCharacter(
       ctx,
       imageData,
-      x + offset * resizeFactor,
-      y + offset * resizeFactor,
+      x,
+      y,
       width,
       scale,
       size,
-      resizeFactor,
       color,
       underline,
       strikethrough,
       bold,
       italic,
-      isAscii
+      isAscii,
+      true
     );
 
     ctx.filter = "brightness(100%)";
@@ -300,13 +297,13 @@ export class FontRenderer {
       width,
       scale,
       size,
-      resizeFactor,
       color,
       underline,
       strikethrough,
       bold,
       italic,
-      isAscii
+      isAscii,
+      false
     );
 
     return this.getCharacterSpacing(char, isAscii, size, scale, width, bold);
@@ -320,25 +317,37 @@ export class FontRenderer {
     width: number,
     scale: number,
     size: number,
-    resizeFactor: number,
     color: Fill,
     underline: boolean,
     strikethrough: boolean,
     bold: boolean,
     italic: boolean,
-    isAscii: boolean
+    isAscii: boolean,
+    isShadow: boolean
   ) {
-    this.fillPlainCharacter(ctx, imageData, x, y, width, scale, size, color, italic);
+    let characterX = x;
+    let characterY = y;
 
-    if (underline) this.fillUnderline(ctx, x, y, width, resizeFactor, color);
-    if (strikethrough) this.fillStrikethrough(ctx, x, y, width, resizeFactor, color);
+    if (isShadow) {
+      const offset = isAscii ? 2 : 1;
+      characterX += offset * scale * size;
+      characterY += offset * scale * size;
+
+      x += 2 * scale * size;
+      y += 2 * scale * size;
+    }
+
+    this.fillPlainCharacter(ctx, imageData, characterX, characterY, width, scale, size, color, italic);
+
+    if (underline) this.fillUnderline(ctx, x, y, width, scale, size, color);
+    if (strikethrough) this.fillStrikethrough(ctx, x, y, width, scale, size, color);
 
     if (bold) {
       this.fillPlainCharacter(
         ctx,
         imageData,
-        x + resizeFactor,
-        y,
+        characterX + (scale * size),
+        characterY,
         width,
         scale,
         size,
@@ -346,23 +355,23 @@ export class FontRenderer {
         italic
       );
 
-      const offset = x + 2 * resizeFactor;
+      const boldOffset = 2 * scale * size;
 
       if (isAscii)
         this.fillPlainCharacter(
           ctx,
           imageData,
-          offset,
-          y,
+          characterX + boldOffset,
+          characterY,
           width,
           scale,
           size,
           color,
           italic
         );
-      if (underline) this.fillUnderline(ctx, offset, y, width, resizeFactor, color);
-      if (strikethrough)
-        this.fillStrikethrough(ctx, offset, y, width, resizeFactor, color);
+
+      if (underline) this.fillUnderline(ctx, x + boldOffset, y, width, scale, size, color);
+      if (strikethrough) this.fillStrikethrough(ctx, x + boldOffset, y, width, scale, size, color);
     }
   }
 
@@ -411,33 +420,23 @@ export class FontRenderer {
     ctx.fill();
   }
 
-  private fillLine(
-    ctx: CanvasRenderingContext2D,
-    x: number,
-    y: number,
-    width: number,
-    resizeFactor: number,
-    color: Fill
-  ) {
-    ctx.fillStyle = color;
-
-    ctx.fillRect(
-      x - 2 * resizeFactor,
-      y,
-      (width + 2) * (resizeFactor * 2),
-      resizeFactor * 2
-    );
-  }
-
   private fillUnderline(
     ctx: CanvasRenderingContext2D,
     x: number,
     y: number,
     width: number,
-    resizeFactor: number,
+    scale: number,
+    size: number,
     color: Fill
   ) {
-    return this.fillLine(ctx, x, y + 16 * resizeFactor, width, resizeFactor, color);
+    ctx.fillStyle = color;
+
+    ctx.fillRect(
+      x - (2 * scale * size),
+      y + (16 * size * scale),
+      (width * size) + (4 * scale * size),
+      2 * scale * size
+    );
   }
 
   private fillStrikethrough(
@@ -445,9 +444,17 @@ export class FontRenderer {
     x: number,
     y: number,
     width: number,
-    resizeFactor: number,
+    scale: number,
+    size: number,
     color: Fill
   ) {
-    return this.fillLine(ctx, x, y + 6 * resizeFactor, width, resizeFactor, color);
+    ctx.fillStyle = color;
+
+    ctx.fillRect(
+      x,
+      y + (6 * scale * size),
+      (width * size) + (2 * scale * size),
+      2 * scale * size
+    );
   }
 }

--- a/packages/schemas/src/player/gamemodes/quests/util.ts
+++ b/packages/schemas/src/player/gamemodes/quests/util.ts
@@ -74,8 +74,6 @@ const processQuests = (
     const k = quest.propertyKey ?? quest.field;
     const field = fieldPrefix ? `${fieldPrefix}_${quest.field}` : quest.field;
 
-    if (time === QuestTime.Monthly) console.log(field);
-
     instance[k] = getQuestCountDuring(time, quests[field]);
     instance.total += instance[k] ?? 0;
   });

--- a/packages/schemas/src/player/gamemodes/skywars/util.ts
+++ b/packages/schemas/src/player/gamemodes/skywars/util.ts
@@ -265,10 +265,7 @@ function createUniformScheme(bracketColor: string, digitColor = bracketColor, em
     const underlineFormat = underline ? "§n" : "";
     const strikethroughFormat = strikethrough ? "§m" : "";
 
-    digitColor = `${digitColor}${underlineFormat}`;
-    emblemColor = `${emblemColor}${underlineFormat}`;
-
-    return `${bracketColor}${underlineFormat}${strikethroughFormat}[§r${boldFormat}${digitColor}${underlineFormat}${level}${emblemColor}${emblem}§r${bracketColor}${underlineFormat}${strikethroughFormat}]§r`;
+    return `${bracketColor}${underlineFormat}${strikethroughFormat}[§r${boldFormat}${digitColor}${underlineFormat}${underlineFormat}${level}${emblemColor}${underlineFormat}${emblem}§r${bracketColor}${underlineFormat}${strikethroughFormat}]§r`;
   };
 }
 
@@ -290,13 +287,11 @@ function createMultiDigitColorScheme(
   const rightBracket = bracketKind === "square" ? "]" : "}";
 
   return (level, bold, underline, strikethrough, emblem) => {
-    console.log(level, bold, underline, strikethrough, emblem);
-
     const boldFormat = bold ? "§l" : "";
     const underlineFormat = underline ? "§n" : "";
     const strikethroughFormat = strikethrough ? "§m" : "";
 
-    colors = colors.map((color) => `${color}${underlineFormat}`) as [
+    const formattedColors = colors.map((color) => `${color}${underlineFormat}`) as [
       leftBracket: string,
       firstDigit: string,
       secondDigit: string,
@@ -305,14 +300,14 @@ function createMultiDigitColorScheme(
       rightBracket: string
     ];
 
-    const formattedEmblem = emblem ? `${colors.at(-2)}${emblem}` : "";
+    const formattedEmblem = emblem ? `${formattedColors.at(-2)}${emblem}` : "";
     const formattedLevel = [...`${level}`]
       .reverse()
-      .map((digit, index) => `${colors[3 - index]}${digit}`)
+      .map((digit, index) => `${formattedColors[3 - index]}${digit}`)
       .reverse()
       .join("");
 
-    return `§r${colors[0]}${strikethroughFormat}${leftBracket}§r${boldFormat}${formattedLevel}${formattedEmblem}§r${colors.at(-1)}${strikethroughFormat}${rightBracket}§r`;
+    return `§r${formattedColors[0]}${strikethroughFormat}${leftBracket}§r${boldFormat}${formattedLevel}${formattedEmblem}§r${formattedColors.at(-1)}${strikethroughFormat}${rightBracket}§r`;
   };
 }
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/e1c5e997-0d8f-4e70-9510-3c09e6840bbc)
![image](https://github.com/user-attachments/assets/804fd36a-3b97-4833-a673-c088cac136ca)

After:
![image](https://github.com/user-attachments/assets/f5fe036f-a07a-4a12-b03c-1d6e48cca2b7)
![image](https://github.com/user-attachments/assets/edcae323-1d42-4b34-b782-b158879e8d35)
