### PR TITLE
fix(schemas): remove _icon prefixes from skywars emblem keys

### DIFF
--- a/packages/schemas/src/player/gamemodes/skywars/index.ts
+++ b/packages/schemas/src/player/gamemodes/skywars/index.ts
@@ -133,7 +133,7 @@ export class SkyWars {
     this.levelFormatted = getFormattedLevel(
       this.level,
       data.active_scheme,
-      data.active_emblem,
+      data.active_emblem?.replace("_icon", ""),
       isBold,
       isUnderline,
       isStrikethrough

--- a/packages/schemas/src/player/gamemodes/skywars/util.ts
+++ b/packages/schemas/src/player/gamemodes/skywars/util.ts
@@ -79,7 +79,7 @@ const EMBLEM_MAP = {
   rich: "$",
   podium: "π",
   fallen_crest: "☬",
-  null_icon: "∅",
+  null: "∅",
   sigma: "Σ",
   delta: "δ",
   florin: "ƒ",


### PR DESCRIPTION
the sigma emblem didn't work because it was called sigma_icon 
Now emblems keys will not have the_icon suffix is 