### PR TITLE
Fixed Hypixel deprecated field for Duels Command

### DIFF
--- a/packages/schemas/src/player/gamemodes/duels/mode.ts
+++ b/packages/schemas/src/player/gamemodes/duels/mode.ts
@@ -38,7 +38,7 @@ export class BaseDuelsGameMode {
     this.losses = data[`${prefix}losses`];
 
     if (mode == "") {
-      this.winstreak = data.current_winstreak;
+      this.winstreak = data.currentStreak;
       this.bestWinstreak = data.best_overall_winstreak;
     } else {
       this.winstreak = data[`current_winstreak_mode_${mode}`];


### PR DESCRIPTION
Description:
Hypixel no longer uses "current_winstreak" and is replaced by "currentStreak"


Related issues:
Duels command shows incorrect Overall Winstreak