### PR TITLE
feat(discord-bot): add guild text exports

### DIFF
--- a/apps/discord-bot/src/commands/guild/guild-export.ts
+++ b/apps/discord-bot/src/commands/guild/guild-export.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Statsify
+ *
+ * This source code is licensed under the GNU GPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ * https://github.com/Statsify/statsify/blob/main/LICENSE
+ */
+
+import { Guild, GuildMember, GuildRank } from "@statsify/schemas";
+
+const getGuildRankMap = (guild: Guild) =>
+  guild.ranks.reduce((acc, rank) => {
+    acc[rank.name] = rank;
+    return acc;
+  }, {} as Record<string, GuildRank>);
+
+const getGuildRankName = (guildRankMap: Record<string, GuildRank>, member: GuildMember) => {
+  const guildRank = guildRankMap[member.rank];
+
+  return guildRank ?
+      `${guildRank.name}${guildRank.tag ? ` [${guildRank.tag}]` : ""}` :
+      member.rank;
+};
+
+const sortGuildMembers = (guild: Guild) => {
+  const guildRankMap = getGuildRankMap(guild);
+
+  return [...guild.members].sort((a, b) => {
+    const priority =
+      (guildRankMap[b.rank]?.priority ?? 0) - (guildRankMap[a.rank]?.priority ?? 0);
+
+    if (priority !== 0) return priority;
+
+    return (a.displayName ?? a.username ?? a.uuid).localeCompare(
+      b.displayName ?? b.username ?? b.uuid
+    );
+  });
+};
+
+export const createGuildListExport = (guild: Guild) => {
+  const guildRankMap = getGuildRankMap(guild);
+  const lines = sortGuildMembers(guild).map(
+    (member) =>
+      `${member.displayName ?? member.username ?? member.uuid}\t${getGuildRankName(guildRankMap, member)}`
+  );
+
+  return [
+    `Guild: ${guild.name}${guild.tag ? ` [${guild.tag}]` : ""}`,
+    `Generated: ${new Date().toISOString()}`,
+    "",
+    "Display Name\tGuild Rank",
+    ...lines,
+  ].join("\n");
+};
+
+export const createGuildTopExport = (
+  guild: Guild,
+  title: string,
+  key: "daily" | "weekly" | "monthly" | number
+) => {
+  const guildRankMap = getGuildRankMap(guild);
+  const lines = [...guild.members]
+    .map((member) => ({
+      member,
+      value: typeof key === "string" ? member[key] : member.expHistory[key],
+    }))
+    .sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
+    .map(
+      ({ member, value }, index) =>
+        `${index + 1}\t${member.displayName ?? member.username ?? member.uuid}\t${getGuildRankName(guildRankMap, member)}\t${value ?? 0}`
+    );
+
+  return [
+    `Guild: ${guild.name}${guild.tag ? ` [${guild.tag}]` : ""}`,
+    `Mode: ${title}`,
+    `Generated: ${new Date().toISOString()}`,
+    "",
+    "Position\tDisplay Name\tGuild Rank\tGEXP",
+    ...lines,
+  ].join("\n");
+};

--- a/apps/discord-bot/src/commands/guild/guild-export.ts
+++ b/apps/discord-bot/src/commands/guild/guild-export.ts
@@ -18,8 +18,8 @@ const getGuildRankName = (guildRankMap: Record<string, GuildRank>, member: Guild
   const guildRank = guildRankMap[member.rank];
 
   return guildRank ?
-      `${guildRank.name}${guildRank.tag ? ` [${guildRank.tag}]` : ""}` :
-      member.rank;
+    `${guildRank.name}${guildRank.tag ? ` [${guildRank.tag}]` : ""}` :
+    member.rank;
 };
 
 const sortGuildMembers = (guild: Guild) => {

--- a/apps/discord-bot/src/commands/guild/guild-top.subcommand.tsx
+++ b/apps/discord-bot/src/commands/guild/guild-top.subcommand.tsx
@@ -19,7 +19,6 @@ import {
 } from "@statsify/discord";
 import { ButtonStyle } from "discord-api-types/v10";
 import { CommandListener } from "#lib/command.listener";
-import { createGuildTopExport } from "./guild-export.js";
 import {
   GUILD_TOP_PAGE_SIZE,
   GuildTopMember,
@@ -29,6 +28,7 @@ import {
 import { GuildLeaderboardSubCommand } from "../leaderboards/guild-leaderboard.subcommand.js";
 import { GuildQuery } from "@statsify/api-client";
 import { Theme, render } from "@statsify/rendering";
+import { createGuildTopExport } from "./guild-export.js";
 import { getBackground, getLogo } from "@statsify/assets";
 import { getTheme } from "#themes";
 

--- a/apps/discord-bot/src/commands/guild/guild-top.subcommand.tsx
+++ b/apps/discord-bot/src/commands/guild/guild-top.subcommand.tsx
@@ -19,6 +19,7 @@ import {
 } from "@statsify/discord";
 import { ButtonStyle } from "discord-api-types/v10";
 import { CommandListener } from "#lib/command.listener";
+import { createGuildTopExport } from "./guild-export.js";
 import {
   GUILD_TOP_PAGE_SIZE,
   GuildTopMember,
@@ -65,6 +66,9 @@ export class GuildTopSubCommand extends GuildLeaderboardSubCommand {
 
     const up = new ButtonBuilder().emoji(t("emojis:up")).style(ButtonStyle.Success);
     const down = new ButtonBuilder().emoji(t("emojis:down")).style(ButtonStyle.Danger);
+    const download = new ButtonBuilder()
+      .label("Download TXT")
+      .style(ButtonStyle.Primary);
 
     const modes: [GuildTopKey, string][] = [
       ["daily", "Today"],
@@ -89,7 +93,10 @@ export class GuildTopSubCommand extends GuildLeaderboardSubCommand {
       )
     );
 
-    const components = [new ActionRowBuilder().component(dropdown)];
+    const components = [
+      new ActionRowBuilder().component(dropdown),
+      new ActionRowBuilder().component(download),
+    ];
 
     const pageCount = Math.ceil(guild.members.length / GUILD_TOP_PAGE_SIZE);
     if (pageCount > 1)
@@ -150,6 +157,23 @@ export class GuildTopSubCommand extends GuildLeaderboardSubCommand {
       })
     );
 
+    listener.addHook(download.getCustomId(), async (interaction) => {
+      if (user?.locale) interaction.setLocale(user.locale);
+
+      return interaction.sendFollowup({
+        files: [
+          {
+            name: "guild-top.txt",
+            data: Buffer.from(
+              createGuildTopExport(guild, modes[modeIndex][1], modes[modeIndex][0])
+            ),
+            type: "text/plain",
+          },
+        ],
+        ephemeral: true,
+      });
+    });
+
     setTimeout(() => {
       context.reply({ components: [] });
       cache.clear();
@@ -157,6 +181,7 @@ export class GuildTopSubCommand extends GuildLeaderboardSubCommand {
       listener.removeHook(up.getCustomId());
       listener.removeHook(down.getCustomId());
       listener.removeHook(dropdown.getCustomId());
+      listener.removeHook(download.getCustomId());
     }, 300_000);
 
     const message = await this.getGuildTopPageMessage(

--- a/apps/discord-bot/src/commands/guild/guild-top.subcommand.tsx
+++ b/apps/discord-bot/src/commands/guild/guild-top.subcommand.tsx
@@ -163,7 +163,7 @@ export class GuildTopSubCommand extends GuildLeaderboardSubCommand {
       return interaction.sendFollowup({
         files: [
           {
-            name: "guild-top.txt",
+            name: `guild-top-${guild.name.toLowerCase().replaceAll(/\W+/g, "-")}.txt`,
             data: Buffer.from(
               createGuildTopExport(guild, modes[modeIndex][1], modes[modeIndex][0])
             ),

--- a/apps/discord-bot/src/commands/guild/guild.command.tsx
+++ b/apps/discord-bot/src/commands/guild/guild.command.tsx
@@ -13,20 +13,20 @@ import {
   Command,
   CommandContext,
   ErrorMessage,
-  Interaction,
   GuildArgument,
   IMessage,
+  Interaction,
   PaginateService,
   PlayerArgument,
   SubCommand,
 } from "@statsify/discord";
 import { ButtonStyle } from "discord-api-types/v10";
+import { CommandListener } from "#lib/command.listener";
 import { GuildListProfile, GuildListProfileProps } from "./guild-list.profile.js";
 import { GuildMember } from "@statsify/schemas";
 import { GuildMemberProfile } from "./guild-member.profile.js";
 import { GuildProfile, GuildProfileProps } from "./guild.profile.js";
 import { GuildQuery } from "@statsify/api-client";
-import { CommandListener } from "#lib/command.listener";
 import { GuildTopSubCommand } from "./guild-top.subcommand.js";
 import { createGuildListExport } from "./guild-export.js";
 import { getAllGameIcons, getBackground, getLogo } from "@statsify/assets";

--- a/apps/discord-bot/src/commands/guild/guild.command.tsx
+++ b/apps/discord-bot/src/commands/guild/guild.command.tsx
@@ -7,22 +7,28 @@
  */
 
 import {
+  ActionRowBuilder,
   ApiService,
+  ButtonBuilder,
   Command,
   CommandContext,
   ErrorMessage,
+  Interaction,
   GuildArgument,
   IMessage,
   PaginateService,
   PlayerArgument,
   SubCommand,
 } from "@statsify/discord";
+import { ButtonStyle } from "discord-api-types/v10";
 import { GuildListProfile, GuildListProfileProps } from "./guild-list.profile.js";
 import { GuildMember } from "@statsify/schemas";
 import { GuildMemberProfile } from "./guild-member.profile.js";
 import { GuildProfile, GuildProfileProps } from "./guild.profile.js";
 import { GuildQuery } from "@statsify/api-client";
+import { CommandListener } from "#lib/command.listener";
 import { GuildTopSubCommand } from "./guild-top.subcommand.js";
+import { createGuildListExport } from "./guild-export.js";
 import { getAllGameIcons, getBackground, getLogo } from "@statsify/assets";
 import { getTheme } from "#themes";
 import { render } from "@statsify/rendering";
@@ -113,9 +119,34 @@ export class GuildCommand extends GuildTopSubCommand {
 
     const canvas = render(<GuildListProfile {...props} />, getTheme(user));
     const buffer = await canvas.toBuffer("png");
+    const download = new ButtonBuilder()
+      .label("Download TXT")
+      .style(ButtonStyle.Primary);
+    const listener = CommandListener.getInstance();
+
+    listener.addHook(download.getCustomId(), async (interaction: Interaction) => {
+      if (user?.locale) interaction.setLocale(user.locale);
+
+      return interaction.sendFollowup({
+        files: [
+          {
+            name: "guild-list.txt",
+            data: Buffer.from(createGuildListExport(guild)),
+            type: "text/plain",
+          },
+        ],
+        ephemeral: true,
+      });
+    });
+
+    setTimeout(() => {
+      context.reply({ components: [] });
+      listener.removeHook(download.getCustomId());
+    }, 300_000);
 
     return {
       files: [{ name: "guild-list.png", data: buffer, type: "image/png" }],
+      components: [new ActionRowBuilder().component(download)],
     };
   }
 


### PR DESCRIPTION
Adds downloadable text exports for guild member and guild top results.
e.g.:
```
Guild: GTB GANG [GTB]
Mode: Today
Generated: 2026-05-30T10:50:12.104Z

Position	Display Name	Guild Rank	GEXP
1	§b[MVP§0+§b] ugcodrr	Guild Master [GM]	4181
2	§b[MVP§0+§b] j4cobi	GANG [GANG]	0
3	§a[VIP] Kwisify	GANG [GANG]	0
```

Closes #365 