### PR TITLE
fix: harden request and search handling

### DIFF
--- a/apps/api/src/player/search/player-search.service.ts
+++ b/apps/api/src/player/search/player-search.service.ts
@@ -25,21 +25,27 @@ export class PlayerSearchService {
 
   public constructor(@InjectRedis() private readonly redis: Redis) {}
 
-  public get(query: string): Promise<string[]> {
+  public async get(query: string): Promise<string[]> {
     try {
-      return this.redis.call(
+      const players = await this.redis.call(
         "FT.SUGGET",
         "player:autocomplete",
         query,
         "FUZZY",
         "MAX",
         "25"
-      ) as Promise<string[]>;
+      ) as unknown;
+
+      if (!Array.isArray(players)) return [];
+
+      return players.filter(
+        (player): player is string => typeof player === "string" && player.length > 0
+      );
     } catch (e) {
       this.logger.error(e);
       this.logger.error(REDI_SEARCH_NOT_INSTALLED);
 
-      return Promise.resolve([]);
+      return [];
     }
   }
 

--- a/apps/site/app/api.ts
+++ b/apps/site/app/api.ts
@@ -12,8 +12,18 @@ import { env } from "~/app/env";
 import type { Guild, Player } from "@statsify/schemas";
 import type { PostLeaderboardResponse } from "@statsify/api-client";
 
+function getApiUrl(path: string, params: Record<string, string> = {}) {
+  const url = new URL(path, env.API_URL);
+
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+
+  return url;
+}
+
 export async function getPlayer(slug: string): Promise<Player | undefined> {
-  const response = await fetch(`${env.API_URL}/player?player=${slug}`, {
+  const response = await fetch(getApiUrl("/player", { player: slug }), {
     headers: { "X-API-KEY": env.API_KEY },
   });
 
@@ -22,7 +32,7 @@ export async function getPlayer(slug: string): Promise<Player | undefined> {
 }
 
 export async function getPlayerSuggestions(query: string): Promise<string[]> {
-  const response = await fetch(`${env.API_URL}/player/search?query=${query}`, {
+  const response = await fetch(getApiUrl("/player/search", { query }), {
     headers: { "X-API-KEY": env.API_KEY },
   });
 
@@ -31,10 +41,10 @@ export async function getPlayerSuggestions(query: string): Promise<string[]> {
 }
 
 export async function getGuild(slug: string): Promise<Guild> {
-  const response = await fetch(`${env.API_URL}/guild?guild=${slug}&type=PLAYER`, {
+  const response = await fetch(getApiUrl("/guild", { guild: slug, type: "PLAYER" }), {
     headers: { "X-API-KEY": env.API_KEY },
-
   });
+
   const { guild } = await response.json();
   return guild;
 }
@@ -55,7 +65,7 @@ export async function getLeaderboard(field: string) {
 }
 
 export async function getSkinRender(uuid: string): Promise<ArrayBuffer> {
-  const response = await fetch(`${env.API_URL}/skin?uuid=${uuid}`, {
+  const response = await fetch(getApiUrl("/skin", { uuid }), {
     headers: { "X-API-KEY": env.API_KEY },
   });
 

--- a/apps/site/app/players/search.tsx
+++ b/apps/site/app/players/search.tsx
@@ -64,8 +64,11 @@ export function Search({
   });
 
   function onSelectionChange(selected: number) {
+    const player = suggestions.data?.[selected];
+    if (!player) return;
+
     setSelected(selected);
-    if (suggestions.data) setInput(suggestions.data[selected]);
+    setInput(player);
 
     const maxScroll = (suggestions.data?.length ?? 0) * SEARCH_ITEM_HEIGHT - SEARCH_MAX_HEIGHT;
     const halfVisible = Math.floor(SEARCH_MAX_HEIGHT / 2);
@@ -87,15 +90,16 @@ export function Search({
         const formData = new FormData(event.currentTarget);
         const query = formData.get("search");
         if (!query || typeof query !== "string") return;
-        console.log(`Redirecting to ${playerUrl(query)}`);
-        router.push(playerUrl(query));
+        const trimmedQuery = query.trim();
+        if (!trimmedQuery) return;
+        router.push(playerUrl(trimmedQuery));
       }}
       onKeyDown={(event) => {
         if (event.key === "Enter") {
           ref.current?.requestSubmit();
         }
 
-        if (suggestions.isPending || suggestions.isError) return;
+        if (suggestions.isPending || suggestions.isError || !suggestions.data?.length) return;
 
         switch (event.key) {
           case "Escape":

--- a/packages/api-client/src/api.service.ts
+++ b/packages/api-client/src/api.service.ts
@@ -295,23 +295,32 @@ export class ApiService {
       description: `${method} ${url}`,
     });
 
-    const res = await this.axios.request({
-      url,
-      method,
-      params,
-      headers,
-      data: body,
-      responseType,
-    });
+    try {
+      const res = await this.axios.request({
+        url,
+        method,
+        params,
+        headers,
+        data: body,
+        responseType,
+      });
 
-    child?.setHttpStatus(res.status);
-    child?.finish();
+      child?.setHttpStatus(res.status);
 
-    const data = res.data;
+      const data = res.data;
 
-    if (data.success === false) throw new Error("API request was unsuccessful");
+      if (data.success === false) throw new Error("API request was unsuccessful");
 
-    return data;
+      return data;
+    } catch (error) {
+      if (Axios.isAxiosError(error) && error.response?.status) {
+        child?.setHttpStatus(error.response.status);
+      }
+
+      throw error;
+    } finally {
+      child?.finish();
+    }
   }
 
   private async requestImage(url: string, params?: Record<string, unknown>) {


### PR DESCRIPTION
Improves a few defensive request/search paths:
- Handles Redis autocomplete command failures in PlayerSearchService.get().
- Ensures API client Sentry HTTP spans finish even when requests fail.
- Encodes site API query parameters and trims empty player search submissions.