### PR TITLE
feat(api): add hypixel proxy endpoints

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { AppController } from "./app.controller.js";
 import { AuthModule } from "#auth";
 import { CommandsModule } from "#commands";
 import { GuildModule } from "#guild";
+import { HypixelProxyModule } from "./hypixel-proxy/hypixel-proxy.module.js";
 import { HypixelResourcesModule } from "#hypixel-resources";
 import { Module } from "@nestjs/common";
 import { PlayerModule } from "#player";
@@ -40,6 +41,7 @@ const redisUrl = await config("database.redisUrl");
     PlayerModule,
     GuildModule,
     HypixelResourcesModule,
+    HypixelProxyModule,
     SkinModule,
     SessionModule,
     AuthModule,

--- a/apps/api/src/hypixel-proxy/dtos.ts
+++ b/apps/api/src/hypixel-proxy/dtos.ts
@@ -7,13 +7,19 @@
  */
 
 import { ApiProperty } from "@nestjs/swagger";
-import { IsOptional, IsString, MaxLength, MinLength } from "class-validator";
+import { IsOptional, IsString, Matches, MaxLength, MinLength } from "class-validator";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{32}$|^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i;
 
 export class RawHypixelPlayerDto {
   @IsOptional()
   @IsString()
   @MinLength(1)
   @MaxLength(36)
+  @Matches(UUID_PATTERN, {
+    message: "uuid must be a valid dashed or undashed Minecraft UUID",
+  })
   @ApiProperty({
     required: false,
     example: "20934ef9488c465180a78f861586b4cf",

--- a/apps/api/src/hypixel-proxy/dtos.ts
+++ b/apps/api/src/hypixel-proxy/dtos.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) Statsify
+ *
+ * This source code is licensed under the GNU GPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ * https://github.com/Statsify/statsify/blob/main/LICENSE
+ */
+
+import { ApiProperty } from "@nestjs/swagger";
+import { IsOptional, IsString, MaxLength, MinLength } from "class-validator";
+
+export class RawHypixelPlayerDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(36)
+  @ApiProperty({
+    required: false,
+    example: "20934ef9488c465180a78f861586b4cf",
+    description: "A player's UUID.",
+  })
+  public uuid?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(16)
+  @ApiProperty({
+    required: false,
+    example: "j4cobi",
+    description: "A player's username.",
+  })
+  public name?: string;
+}
+
+export class RawHypixelGuildDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(36)
+  @ApiProperty({
+    required: false,
+    example: "66f5afec8ea8c9b409f58739",
+    description: "A guild id.",
+  })
+  public id?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(36)
+  @ApiProperty({
+    required: false,
+    example: "BlueBloods",
+    description: "A guild name.",
+  })
+  public name?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(36)
+  @ApiProperty({
+    required: false,
+    example: "j4cobi",
+    description: "A player UUID or username.",
+  })
+  public player?: string;
+}

--- a/apps/api/src/hypixel-proxy/hypixel-proxy.controller.ts
+++ b/apps/api/src/hypixel-proxy/hypixel-proxy.controller.ts
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) Statsify
+ *
+ * This source code is licensed under the GNU GPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ * https://github.com/Statsify/statsify/blob/main/LICENSE
+ */
+
+import {
+  ApiBadGatewayResponse,
+  ApiBadRequestResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from "@nestjs/swagger";
+import { Auth } from "#auth";
+import { Controller, Get, Query, Res } from "@nestjs/common";
+import { ErrorResponse } from "@statsify/api-client";
+import { FastifyReply } from "fastify";
+import { HypixelService } from "#hypixel";
+import {
+  RawHypixelGamecountsResponse,
+  RawHypixelGuildResponse,
+  RawHypixelPlayerResponse,
+  RawHypixelWatchdogStatsResponse,
+} from "./responses.js";
+import { RawHypixelGuildDto, RawHypixelPlayerDto } from "./dtos.js";
+
+@Controller("/hypixel")
+@ApiTags("Hypixel Proxy")
+export class HypixelProxyController {
+  public constructor(private readonly hypixelService: HypixelService) {}
+
+  @Get("/player")
+  @ApiOperation({
+    summary: "Get a Raw Hypixel Player Response",
+    description:
+      "Proxies Hypixel's `/player` endpoint behind Statsify auth. `name` is resolved to a UUID before Hypixel is called. Upstream Hypixel responses, including non-2xx responses, are forwarded verbatim.",
+  })
+  @ApiQuery({
+    name: "uuid",
+    required: false,
+    description: "A player's UUID. Provide exactly one of `uuid` or `name`.",
+  })
+  @ApiQuery({
+    name: "name",
+    required: false,
+    description:
+      "A player's username. Statsify resolves it to a UUID through Mojang before calling Hypixel.",
+  })
+  @ApiOkResponse({ type: RawHypixelPlayerResponse })
+  @ApiBadRequestResponse({
+    type: ErrorResponse,
+    description: "Exactly one of `uuid` or `name` is required.",
+  })
+  @ApiNotFoundResponse({
+    type: ErrorResponse,
+    description: "Returned locally when Mojang cannot resolve `name` to a UUID.",
+  })
+  @ApiBadGatewayResponse({
+    type: ErrorResponse,
+    description:
+      "Returned locally when Statsify cannot reach Mojang or Hypixel before an upstream response exists.",
+  })
+  @Auth()
+  public async getPlayer(@Query() query: RawHypixelPlayerDto, @Res() reply: FastifyReply) {
+    const response = await this.hypixelService.getRawPlayer(query);
+    return reply.status(response.status).send(response.data);
+  }
+
+  @Get("/guild")
+  @ApiOperation({
+    summary: "Get a Raw Hypixel Guild Response",
+    description:
+      "Proxies Hypixel's `/guild` endpoint behind Statsify auth. `player` usernames are resolved to UUIDs before Hypixel is called. Upstream Hypixel responses, including non-2xx responses, are forwarded verbatim.",
+  })
+  @ApiQuery({
+    name: "id",
+    required: false,
+    description: "A guild id. Provide exactly one of `id`, `name`, or `player`.",
+  })
+  @ApiQuery({
+    name: "name",
+    required: false,
+    description: "A guild name. Provide exactly one of `id`, `name`, or `player`.",
+  })
+  @ApiQuery({
+    name: "player",
+    required: false,
+    description:
+      "A player's UUID or username. Usernames are resolved to UUIDs through Mojang before calling Hypixel.",
+  })
+  @ApiOkResponse({ type: RawHypixelGuildResponse })
+  @ApiBadRequestResponse({
+    type: ErrorResponse,
+    description: "Exactly one of `id`, `name`, or `player` is required.",
+  })
+  @ApiNotFoundResponse({
+    type: ErrorResponse,
+    description: "Returned locally when Mojang cannot resolve `player` to a UUID.",
+  })
+  @ApiBadGatewayResponse({
+    type: ErrorResponse,
+    description:
+      "Returned locally when Statsify cannot reach Mojang or Hypixel before an upstream response exists.",
+  })
+  @Auth({ weight: 120 })
+  public async getGuild(@Query() query: RawHypixelGuildDto, @Res() reply: FastifyReply) {
+    const response = await this.hypixelService.getRawGuild(query);
+    return reply.status(response.status).send(response.data);
+  }
+
+  @Get("/watchdogstats")
+  @ApiOperation({
+    summary: "Get a Raw Hypixel Watchdog Stats Response",
+    description:
+      "Proxies Hypixel's `/watchdogstats` endpoint behind Statsify auth. Upstream Hypixel responses, including non-2xx responses, are forwarded verbatim.",
+  })
+  @ApiOkResponse({ type: RawHypixelWatchdogStatsResponse })
+  @ApiBadGatewayResponse({
+    type: ErrorResponse,
+    description: "Returned locally when Statsify cannot reach Hypixel before an upstream response exists.",
+  })
+  @Auth()
+  public async getWatchdogStats(@Res() reply: FastifyReply) {
+    const response = await this.hypixelService.getRawWatchdogStats();
+    return reply.status(response.status).send(response.data);
+  }
+
+  @Get("/gamecounts")
+  @ApiOperation({
+    summary: "Get a Raw Hypixel Game Counts Response",
+    description:
+      "Proxies Hypixel's `/gamecounts` endpoint behind Statsify auth. Upstream Hypixel responses, including non-2xx responses, are forwarded verbatim.",
+  })
+  @ApiOkResponse({ type: RawHypixelGamecountsResponse })
+  @ApiBadGatewayResponse({
+    type: ErrorResponse,
+    description: "Returned locally when Statsify cannot reach Hypixel before an upstream response exists.",
+  })
+  @Auth()
+  public async getGameCounts(@Res() reply: FastifyReply) {
+    const response = await this.hypixelService.getRawGameCounts();
+    return reply.status(response.status).send(response.data);
+  }
+}

--- a/apps/api/src/hypixel-proxy/hypixel-proxy.module.ts
+++ b/apps/api/src/hypixel-proxy/hypixel-proxy.module.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Statsify
+ *
+ * This source code is licensed under the GNU GPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ * https://github.com/Statsify/statsify/blob/main/LICENSE
+ */
+
+import { HypixelModule } from "#hypixel";
+import { HypixelProxyController } from "./hypixel-proxy.controller.js";
+import { Module } from "@nestjs/common";
+
+@Module({
+  imports: [HypixelModule],
+  controllers: [HypixelProxyController],
+})
+export class HypixelProxyModule {}

--- a/apps/api/src/hypixel-proxy/responses.ts
+++ b/apps/api/src/hypixel-proxy/responses.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Statsify
+ *
+ * This source code is licensed under the GNU GPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ * https://github.com/Statsify/statsify/blob/main/LICENSE
+ */
+
+import { ApiProperty } from "@nestjs/swagger";
+
+export class RawHypixelPlayerResponse {
+  @ApiProperty()
+  public success: boolean;
+
+  @ApiProperty({
+    type: "object",
+    nullable: true,
+    additionalProperties: true,
+  })
+  public player: Record<string, unknown> | null;
+}
+
+export class RawHypixelGuildResponse {
+  @ApiProperty()
+  public success: boolean;
+
+  @ApiProperty({
+    type: "object",
+    nullable: true,
+    additionalProperties: true,
+  })
+  public guild: Record<string, unknown> | null;
+}
+
+export class RawHypixelWatchdogStatsResponse {
+  @ApiProperty({
+    description: "The raw Hypixel response includes additional top-level watchdog stats fields.",
+  })
+  public success: boolean;
+}
+
+export class RawHypixelGamecountsResponse {
+  @ApiProperty()
+  public success: boolean;
+
+  @ApiProperty({
+    type: "object",
+    additionalProperties: true,
+  })
+  public games: Record<string, unknown>;
+}

--- a/apps/api/src/hypixel/hypixel.module.ts
+++ b/apps/api/src/hypixel/hypixel.module.ts
@@ -9,10 +9,12 @@
 import { HttpModule } from "@nestjs/axios";
 import { HypixelService } from "./hypixel.service.js";
 import { Module } from "@nestjs/common";
+import { MojangModule } from "../mojang/mojang.module.js";
 import { config } from "@statsify/util";
 
 @Module({
   imports: [
+    MojangModule,
     HttpModule.register({
       baseURL: "https://api.hypixel.net/",
       headers: {

--- a/apps/api/src/hypixel/hypixel.service.ts
+++ b/apps/api/src/hypixel/hypixel.service.ts
@@ -159,7 +159,10 @@ export class HypixelService {
   }): Promise<RawHypixelResponse> {
     this.assertExactlyOne("/hypixel/player", { name, uuid });
 
-    const resolvedUuid = await this.playerUuidResolverService.resolvePlayerUuid(uuid ?? name!);
+    const resolvedUuid = uuid ?
+      this.normalizeUuid(uuid) :
+      await this.playerUuidResolverService.resolvePlayerUuid(name!);
+
     return this.requestRaw("/player", { uuid: resolvedUuid });
   }
 
@@ -255,5 +258,9 @@ export class HypixelService {
     throw new BadRequestException(
       `${route} requires exactly one of ${Object.keys(params).join(", ")}`
     );
+  }
+
+  private normalizeUuid(uuid: string) {
+    return uuid.replaceAll("-", "").toLowerCase();
   }
 }

--- a/apps/api/src/hypixel/hypixel.service.ts
+++ b/apps/api/src/hypixel/hypixel.service.ts
@@ -7,6 +7,7 @@
  */
 
 import * as Sentry from "@sentry/node";
+import { BadGatewayException, BadRequestException, Injectable } from "@nestjs/common";
 import { CacheLevel } from "@statsify/api-client";
 import {
   GameCounts,
@@ -17,17 +18,25 @@ import {
   Watchdog,
 } from "@statsify/schemas";
 import { HttpService } from "@nestjs/axios";
-import { Injectable } from "@nestjs/common";
 import { Logger } from "@statsify/logger";
 import { Observable, catchError, lastValueFrom, map, of, tap, throwError } from "rxjs";
+import { PlayerUuidResolverService } from "../mojang/player-uuid-resolver.service.js";
 import type { APIData } from "@statsify/util";
+
+interface RawHypixelResponse<T = APIData> {
+  status: number;
+  data: T;
+}
 
 @Injectable()
 export class HypixelService {
   private readonly logger = new Logger("HypixelService");
   private resources = new Map<string, APIData>();
 
-  public constructor(private readonly httpService: HttpService) {}
+  public constructor(
+    private readonly httpService: HttpService,
+    private readonly playerUuidResolverService: PlayerUuidResolverService
+  ) {}
 
   public shouldCache(expirey: number, cache: CacheLevel): boolean {
     return (
@@ -141,6 +150,45 @@ export class HypixelService {
     return this.resources.get(resource);
   }
 
+  public async getRawPlayer({
+    name,
+    uuid,
+  }: {
+    name?: string;
+    uuid?: string;
+  }): Promise<RawHypixelResponse> {
+    this.assertExactlyOne("/hypixel/player", { name, uuid });
+
+    const resolvedUuid = await this.playerUuidResolverService.resolvePlayerUuid(uuid ?? name!);
+    return this.requestRaw("/player", { uuid: resolvedUuid });
+  }
+
+  public async getRawGuild({
+    id,
+    name,
+    player,
+  }: {
+    id?: string;
+    name?: string;
+    player?: string;
+  }): Promise<RawHypixelResponse> {
+    this.assertExactlyOne("/hypixel/guild", { id, name, player });
+
+    if (id) return this.requestRaw("/guild", { id });
+    if (name) return this.requestRaw("/guild", { name });
+
+    const resolvedPlayer = await this.playerUuidResolverService.resolvePlayerUuid(player!);
+    return this.requestRaw("/guild", { player: resolvedPlayer });
+  }
+
+  public getRawWatchdogStats(): Promise<RawHypixelResponse> {
+    return this.requestRaw("/watchdogstats");
+  }
+
+  public getRawGameCounts(): Promise<RawHypixelResponse> {
+    return this.requestRaw("/gamecounts");
+  }
+
   private request<T>(url: string, params?: Record<string, unknown>): Observable<T> {
     const transaction = Sentry.getCurrentHub().getScope()?.getTransaction();
 
@@ -163,6 +211,49 @@ export class HypixelService {
             })
         )
       )
+    );
+  }
+
+  private async requestRaw<T = APIData>(
+    url: string,
+    params?: Record<string, unknown>
+  ): Promise<RawHypixelResponse<T>> {
+    const transaction = Sentry.getCurrentHub().getScope()?.getTransaction();
+    const description = `GET ${this.httpService.axiosRef.getUri({ url, params })}`;
+
+    const child = transaction?.startChild({
+      op: "http.client",
+      description,
+    });
+
+    try {
+      const response = await this.httpService.axiosRef.request<T>({
+        url,
+        method: "GET",
+        params,
+        validateStatus: () => true,
+      });
+
+      child?.setHttpStatus(response.status);
+
+      return {
+        status: response.status,
+        data: response.data,
+      };
+    } catch {
+      throw new BadGatewayException("Failed to reach Hypixel API");
+    } finally {
+      child?.finish();
+    }
+  }
+
+  private assertExactlyOne(route: string, params: Record<string, string | undefined>) {
+    const usedParams = Object.entries(params).filter(([, value]) => value !== undefined);
+
+    if (usedParams.length === 1) return;
+
+    throw new BadRequestException(
+      `${route} requires exactly one of ${Object.keys(params).join(", ")}`
     );
   }
 }

--- a/apps/api/src/mojang/mojang.module.ts
+++ b/apps/api/src/mojang/mojang.module.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Statsify
+ *
+ * This source code is licensed under the GNU GPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ * https://github.com/Statsify/statsify/blob/main/LICENSE
+ */
+
+import { HttpModule } from "@nestjs/axios";
+import { Module } from "@nestjs/common";
+import { PlayerUuidResolverService } from "./player-uuid-resolver.service.js";
+
+@Module({
+  imports: [HttpModule.register({})],
+  providers: [PlayerUuidResolverService],
+  exports: [PlayerUuidResolverService],
+})
+export class MojangModule {}

--- a/apps/api/src/mojang/player-uuid-resolver.service.ts
+++ b/apps/api/src/mojang/player-uuid-resolver.service.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Statsify
+ *
+ * This source code is licensed under the GNU GPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ * https://github.com/Statsify/statsify/blob/main/LICENSE
+ */
+
+import {
+  BadGatewayException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { HttpService } from "@nestjs/axios";
+
+interface MojangProfile {
+  id: string;
+}
+
+@Injectable()
+export class PlayerUuidResolverService {
+  public constructor(private readonly httpService: HttpService) {}
+
+  public async resolvePlayerUuid(input: string): Promise<string> {
+    if (this.isUuid(input)) return this.normalizeUuid(input);
+
+    try {
+      const response = await this.httpService.axiosRef.get<MojangProfile>(
+        `https://api.mojang.com/users/profiles/minecraft/${input}`,
+        { validateStatus: () => true }
+      );
+
+      if (response.status === 200 && response.data?.id) {
+        return this.normalizeUuid(response.data.id);
+      }
+
+      if (response.status === 404) {
+        throw new NotFoundException("Player name could not be resolved to a UUID");
+      }
+
+      throw new BadGatewayException("Failed to reach Mojang API");
+    } catch (error) {
+      if (error instanceof NotFoundException || error instanceof BadGatewayException) {
+        throw error;
+      }
+
+      throw new BadGatewayException("Failed to reach Mojang API");
+    }
+  }
+
+  private isUuid(input: string) {
+    return /^[0-9a-f]{32}$/i.test(input) || /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(input);
+  }
+
+  private normalizeUuid(uuid: string) {
+    return uuid.replaceAll("-", "").toLowerCase();
+  }
+}

--- a/apps/api/src/skin/skin.module.ts
+++ b/apps/api/src/skin/skin.module.ts
@@ -8,6 +8,7 @@
 
 import { HttpModule } from "@nestjs/axios";
 import { Module } from "@nestjs/common";
+import { MojangModule } from "../mojang/mojang.module.js";
 import { Skin } from "@statsify/schemas";
 import { SkinController } from "./skin.controller.js";
 import { SkinService } from "./skin.service.js";
@@ -15,6 +16,7 @@ import { TypegooseModule } from "@m8a/nestjs-typegoose";
 
 @Module({
   imports: [
+    MojangModule,
     TypegooseModule.forFeature([Skin]),
     HttpModule.register({}),
   ],

--- a/apps/api/src/skin/skin.service.ts
+++ b/apps/api/src/skin/skin.service.ts
@@ -9,8 +9,13 @@
 import { Canvas, type Image } from "skia-canvas";
 import { HttpService } from "@nestjs/axios";
 import { InjectModel } from "@m8a/nestjs-typegoose";
-import { Injectable, InternalServerErrorException } from "@nestjs/common";
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from "@nestjs/common";
 import { PlayerNotFoundException } from "@statsify/api-client";
+import { PlayerUuidResolverService } from "../mojang/player-uuid-resolver.service.js";
 import { Skin } from "@statsify/schemas";
 import { catchError, lastValueFrom, map } from "rxjs";
 import { getMinecraftTexturePath } from "@statsify/assets";
@@ -22,6 +27,7 @@ import type { ReturnModelType } from "@typegoose/typegoose";
 export class SkinService {
   public constructor(
     private readonly httpService: HttpService,
+    private readonly playerUuidResolverService: PlayerUuidResolverService,
     @InjectModel(Skin) private readonly skinModel: ReturnModelType<typeof Skin>
   ) {}
 
@@ -66,7 +72,12 @@ export class SkinService {
       return cachedSkin;
     }
 
-    const uuid = isUsername ? await this.getUuid(tag) : tag;
+    const uuid = isUsername ?
+      await this.playerUuidResolverService.resolvePlayerUuid(tag).catch((error) => {
+        if (error instanceof NotFoundException) throw new PlayerNotFoundException();
+        throw new InternalServerErrorException();
+      }) :
+      tag;
 
     const skin = await this.requestSkin(uuid).catch((error) => {
       if (cachedSkin) return cachedSkin;
@@ -100,23 +111,6 @@ export class SkinService {
     };
   }
 
-  private getUuid(username: string): Promise<string> {
-    return lastValueFrom(
-      this.httpService.get(`https://api.mojang.com/users/profiles/minecraft/${username}`).pipe(
-        map((response) => response.data as MojangProfile),
-        map((data) => data.id),
-        catchError((error) => {
-          if (error.response.status === 404) throw new PlayerNotFoundException();
-          // Ratelimited
-          if (error.response.status === 429) throw new InternalServerErrorException();
-
-          // Unknown
-          throw new InternalServerErrorException();
-        })
-      )
-    );
-  }
-
   private requestSkin(uuid: string) {
     return lastValueFrom(
       this.httpService.get(`https://sessionserver.mojang.com/session/minecraft/profile/${uuid}`).pipe(
@@ -133,11 +127,4 @@ export class SkinService {
       )
     );
   }
-}
-
-interface MojangProfile {
-  id: string;
-  name: string;
-  legacy?: true;
-  demo?: true;
 }


### PR DESCRIPTION
Adds a dedicated `/hypixel` passthrough namespace for raw upstream Hypixel responses behind normal Statsify auth and rate limiting.

Includes:
- `/hypixel/player`, `/hypixel/guild`, `/hypixel/watchdogstats`, and `/hypixel/gamecounts`
- Verbatim upstream status/body passthrough when Hypixel responds
- Local validation for mutually exclusive query params
- Mojang username-to-UUID resolution for `/hypixel/player?name=...` and `/hypixel/guild?player=...`
- Local `404` for unresolved Mojang names and local `502` for Mojang/Hypixel transport failures
- Swagger/Redoc docs for the new passthrough routes
- No changes to `@statsify/api-client`

Checks run:
- pnpm --filter api test:types
- pnpm --filter api lint
- git diff --check