### PR TITLE
fix: stabilize guild monthly leaderboards

### DIFF
--- a/apps/api/src/guild/guild.service.ts
+++ b/apps/api/src/guild/guild.service.ts
@@ -22,6 +22,24 @@ import { PlayerService } from "#player";
 import { flatten } from "@statsify/util";
 import type { ReturnModelType } from "@typegoose/typegoose";
 
+function getExpHistory(days: string[] = [], expHistory: number[] = []) {
+  return Object.fromEntries(days.map((day, index) => [day, expHistory[index] ?? 0]));
+}
+
+function mergeExpHistory(
+  cachedDays: string[] | undefined,
+  cachedExpHistory: number[] | undefined,
+  currentExpHistory: Record<string, number>
+) {
+  const combinedExpHistory = getExpHistory(cachedDays, cachedExpHistory);
+
+  Object.entries(currentExpHistory).forEach(([day, exp]) => {
+    combinedExpHistory[day] = Math.max(combinedExpHistory[day] ?? 0, exp);
+  });
+
+  return combinedExpHistory;
+}
+
 @Injectable()
 export class GuildService {
   private readonly logger = new Logger("GuildService");
@@ -84,7 +102,7 @@ export class GuildService {
 
       // Merge the exp history from hypixel and the cached guild
       const combinedExpHistory: Record<string, number> = {
-        ...this.getExpHistory(cacheMember?.expHistoryDays, cacheMember?.expHistory),
+        ...getExpHistory(cacheMember?.expHistoryDays, cacheMember?.expHistory),
         ...Object.fromEntries(
           member.expHistoryDays.map((day, index) => [day, member.expHistory[index]])
         ),
@@ -114,7 +132,11 @@ export class GuildService {
       .lean()
       .exec();
 
-    const combinedGuildExpHistory = this.getCombinedExpHistory(cachedGuild, guildExpHistory);
+    const combinedGuildExpHistory = mergeExpHistory(
+      cachedGuild?.expHistoryDays,
+      cachedGuild?.expHistory,
+      guildExpHistory
+    );
 
     // Get scaled gexp
     Object.entries(combinedGuildExpHistory)
@@ -254,27 +276,6 @@ export class GuildService {
     }
   }
 
-  private getExpHistory(days: string[] = [], expHistory: number[] = []) {
-    return Object.fromEntries(days.map((day, index) => [day, expHistory[index] ?? 0]));
-  }
-
-  private getCombinedExpHistory(
-    cachedGuild: Guild | null,
-    guildExpHistory: Record<string, number>
-  ) {
-    // Preserve cached guild totals so GEXP does not drop when member history disappears.
-    const combinedGuildExpHistory = this.getExpHistory(
-      cachedGuild?.expHistoryDays,
-      cachedGuild?.expHistory
-    );
-
-    Object.entries(guildExpHistory).forEach(([day, exp]) => {
-      combinedGuildExpHistory[day] = Math.max(combinedGuildExpHistory[day] ?? 0, exp);
-    });
-
-    return combinedGuildExpHistory;
-  }
-
   private scaleGexp(exp: number) {
     if (exp <= 200_000) return exp;
     if (exp <= 700_000) return (exp - 200_000) / 10 + 200_000;
@@ -287,18 +288,9 @@ if (import.meta.vitest) {
 
   suite("GuildService", () => {
     it("preserves cached guild exp history when refreshed member totals are lower", () => {
-      const service = Object.create(GuildService.prototype) as {
-        getCombinedExpHistory: (
-          cachedGuild: Pick<Guild, "expHistoryDays" | "expHistory">,
-          guildExpHistory: Record<string, number>
-        ) => Record<string, number>;
-      };
-
-      const combined = service.getCombinedExpHistory(
-        {
-          expHistoryDays: ["2026-05-12", "2026-05-11", "2026-05-10"],
-          expHistory: [500, 400, 300],
-        } as Guild,
+      const combined = mergeExpHistory(
+        ["2026-05-12", "2026-05-11", "2026-05-10"],
+        [500, 400, 300],
         {
           "2026-05-12": 250,
           "2026-05-11": 450,

--- a/apps/api/src/guild/guild.service.ts
+++ b/apps/api/src/guild/guild.service.ts
@@ -84,10 +84,7 @@ export class GuildService {
 
       // Merge the exp history from hypixel and the cached guild
       const combinedExpHistory: Record<string, number> = {
-        ...cacheMember?.expHistoryDays?.reduce(
-          (acc, day, index) => ({ ...acc, [day]: cacheMember.expHistory[index] }),
-          {}
-        ),
+        ...this.getExpHistory(cacheMember?.expHistoryDays, cacheMember?.expHistory),
         ...Object.fromEntries(
           member.expHistoryDays.map((day, index) => [day, member.expHistory[index]])
         ),

--- a/apps/api/src/guild/guild.service.ts
+++ b/apps/api/src/guild/guild.service.ts
@@ -117,8 +117,10 @@ export class GuildService {
       .lean()
       .exec();
 
+    const combinedGuildExpHistory = this.getCombinedExpHistory(cachedGuild, guildExpHistory);
+
     // Get scaled gexp
-    Object.entries(guildExpHistory)
+    Object.entries(combinedGuildExpHistory)
       .sort()
       .toReversed()
       .slice(0, 30)
@@ -255,9 +257,62 @@ export class GuildService {
     }
   }
 
+  private getExpHistory(days: string[] = [], expHistory: number[] = []) {
+    return Object.fromEntries(days.map((day, index) => [day, expHistory[index] ?? 0]));
+  }
+
+  private getCombinedExpHistory(
+    cachedGuild: Guild | null,
+    guildExpHistory: Record<string, number>
+  ) {
+    // Preserve cached guild totals so GEXP does not drop when member history disappears.
+    const combinedGuildExpHistory = this.getExpHistory(
+      cachedGuild?.expHistoryDays,
+      cachedGuild?.expHistory
+    );
+
+    Object.entries(guildExpHistory).forEach(([day, exp]) => {
+      combinedGuildExpHistory[day] = Math.max(combinedGuildExpHistory[day] ?? 0, exp);
+    });
+
+    return combinedGuildExpHistory;
+  }
+
   private scaleGexp(exp: number) {
     if (exp <= 200_000) return exp;
     if (exp <= 700_000) return (exp - 200_000) / 10 + 200_000;
     return Math.round((exp - 700_000) / 33 + 250_000);
   }
+}
+
+if (import.meta.vitest) {
+  const { suite, it, expect } = import.meta.vitest;
+
+  suite("GuildService", () => {
+    it("preserves cached guild exp history when refreshed member totals are lower", () => {
+      const service = Object.create(GuildService.prototype) as {
+        getCombinedExpHistory: (
+          cachedGuild: Pick<Guild, "expHistoryDays" | "expHistory">,
+          guildExpHistory: Record<string, number>
+        ) => Record<string, number>;
+      };
+
+      const combined = service.getCombinedExpHistory(
+        {
+          expHistoryDays: ["2026-05-12", "2026-05-11", "2026-05-10"],
+          expHistory: [500, 400, 300],
+        } as Guild,
+        {
+          "2026-05-12": 250,
+          "2026-05-11": 450,
+        }
+      );
+
+      expect(combined).toEqual({
+        "2026-05-12": 500,
+        "2026-05-11": 450,
+        "2026-05-10": 300,
+      });
+    });
+  });
 }

--- a/apps/api/src/guild/leaderboards/guild-leaderboard.service.ts
+++ b/apps/api/src/guild/leaderboards/guild-leaderboard.service.ts
@@ -67,8 +67,8 @@ export class GuildLeaderboardService extends LeaderboardService {
           .lean()
           .exec();
 
-        const additionalStats = flatten(guild) as LeaderboardAdditionalStats;
-        additionalStats.name = additionalStats.nameFormatted;
+        const additionalStats = flatten(guild ?? {}) as LeaderboardAdditionalStats;
+        additionalStats.name = additionalStats.nameFormatted ?? guild?.name ?? id;
 
         return additionalStats;
       })

--- a/apps/api/src/guild/leaderboards/guild-leaderboard.service.ts
+++ b/apps/api/src/guild/leaderboards/guild-leaderboard.service.ts
@@ -56,6 +56,7 @@ export class GuildLeaderboardService extends LeaderboardService {
     }, {} as Record<string, boolean>);
 
     selector.nameFormatted = true;
+    selector.name = true;
 
     return await Promise.all(
       ids.map(async (id) => {

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": [
     "src",
-    "eslint.config.js"
+    "eslint.config.js",
+    "vitest.config.ts"
   ]
 }

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Statsify
+ *
+ * This source code is licensed under the GNU GPL v3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ * https://github.com/Statsify/statsify/blob/main/LICENSE
+ */
+
+import { config } from "../../vitest.shared.js";
+
+export default await config();


### PR DESCRIPTION
## Summary
- preserve cached per-day guild GEXP totals when recomputing rolling daily/weekly/monthly values
- prevent monthly/scaled monthly GEXP from dropping when member history disappears from the current Hypixel guild member list
- keep guild leaderboard rendering resilient when a stale leaderboard id maps to a missing or partial guild document
- reuse the shared exp-history merge helper for member history so the cached/current GEXP merge avoids per-day object spreading and extra allocations

## Root Cause
Guild monthly GEXP was recomputed only from the current Hypixel member list. If a member left, or if current member history omitted a day that was previously cached, that contribution disappeared from the recomputed 30-day aggregate and Redis leaderboard scores could be updated downward without an actual monthly reset.

The member-level cached/current history merge also rebuilt the accumulator object on every cached day. Reusing the same helper used by the guild-level preserved totals keeps the stabilization behavior intact while reducing temporary allocations during guild refreshes.

## Testing
- pnpm --filter api test:types
- pnpm vitest --project api