### PR TITLE
fix: address low-risk repo cleanup and performance issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A Hypixel and Minecraft focused Discord Bot
 
 ### 🚀 Running
 * The codebase is split into apps and packages
-* Set up a `config.js` file in the root of the project following the `config.schema.js` file (copy paste it over and fill it in)
+* Set up a `config.js` file in the root of the project following the `config.schema.js` file (copy and paste it over and fill it in)
 * Pull the git submodules (`git submodule update --init`)
 * Set up the assets by running `cd assets/public && pnpm`
 * Use `pnpm build` to build all packages and apps,
@@ -35,10 +35,10 @@ A Hypixel and Minecraft focused Discord Bot
 ### 🤖 Other Important commands
 ```bash
 # Change things in a package/app
-$ pnpm workspace {app or package name} {command}
+$ pnpm --filter {app or package name} {command}
 
 # Example: Adding a dependency
-$ pnpm workspace {app or package name} add {dependency}
+$ pnpm --filter {app or package name} add {dependency}
 
 # Linting
 $ pnpm lint

--- a/apps/scripts/src/api-key.js
+++ b/apps/scripts/src/api-key.js
@@ -186,7 +186,7 @@ const deleteKey = async () => {
     },
   ]);
 
-  if (!(await inquirerConfirmation(false))) return;
+  if (!(await inquirerConfirmation("Are you sure?", false))) return;
 
   const activeKeys = await getKeys();
 

--- a/apps/scripts/src/limit-redis.js
+++ b/apps/scripts/src/limit-redis.js
@@ -15,8 +15,15 @@ import { SimpleIntervalJob, Task } from "toad-scheduler";
 const logger = new Logger("Redis Limiter");
 const redis = new Redis(process.env.REDIS_URL);
 
+const getLeaderboardPath = (constructor, key, prefix) => {
+  const name = constructor.name.toLowerCase();
+  const path = `${name}.${key}`;
+
+  return prefix ? `${prefix}:${path}` : path;
+};
+
 const runLimit = async (constructors, prefixes) => {
-  constructors.forEach(async (constructor, i) => {
+  await Promise.all(constructors.map(async (constructor, i) => {
     const oldLeaderboardPipeline = redis.pipeline();
     const limitLeaderboardPipeline = redis.pipeline();
 
@@ -24,7 +31,7 @@ const runLimit = async (constructors, prefixes) => {
     const fields = MetadataScanner.scan(constructor);
 
     fields.forEach(([key, value]) => {
-      const path = prefixes ? `${prefixes[i]}:${name}.${key}` : `${name}.${key}`;
+      const path = getLeaderboardPath(constructor, key, prefixes?.[i]);
       if (!value.leaderboard.enabled || (prefixes ? !value.historical.enabled : false))
         oldLeaderboardPipeline.del(path);
     });
@@ -38,7 +45,7 @@ const runLimit = async (constructors, prefixes) => {
     let memberCount = 0;
 
     leaderboards.forEach(([key, value]) => {
-      const path = `${name}.${key}`;
+      const path = getLeaderboardPath(constructor, key, prefixes?.[i]);
       const { sort } = value.leaderboard;
       let { limit } = value.leaderboard;
       if (limit === Number.POSITIVE_INFINITY) return;
@@ -63,7 +70,7 @@ const runLimit = async (constructors, prefixes) => {
         prefixes ? prefixes[i].toLowerCase() : "lifetime"
       } ${name} leaderboards`
     );
-  });
+  }));
 };
 
 const limit = async () => {

--- a/apps/scripts/src/timestamp.js
+++ b/apps/scripts/src/timestamp.js
@@ -84,11 +84,11 @@ const setTimestamps = async (collectionName) => {
 
   if (!bulkOperations.length)
     return console.log(`No players to update for ${collectionName}.`);
-  collection.bulkWrite(bulkOperations).then((res) => {
-    console.log(
-      `Updated ${res.modifiedCount}/${players.length} players for ${collectionName}.`
-    );
-  });
+  const res = await collection.bulkWrite(bulkOperations);
+
+  console.log(
+    `Updated ${res.modifiedCount}/${players.length} players for ${collectionName}.`
+  );
 };
 
 await setTimestamps("daily");

--- a/apps/scripts/src/validate-commands.js
+++ b/apps/scripts/src/validate-commands.js
@@ -6,7 +6,7 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import commands from "discord-bot/commands.json" assert { type: "json" };
+import commands from "discord-bot/commands.json" with { type: "json" };
 import z from "zod";
 
 function toEnum(...args) {
@@ -14,10 +14,10 @@ function toEnum(...args) {
 }
 
 const name = z.string().min(3).max(32);
-const name_localizations = z.optional(z.record(name));
+const name_localizations = z.optional(z.record(z.string(), name));
 
 const description = z.string().min(1).max(100);
-const description_localizations = z.optional(z.record(description));
+const description_localizations = z.optional(z.record(z.string(), description));
 
 const choicesSchema = z.object({
   // this is intentional since choice names can go up to 100 characters
@@ -58,9 +58,9 @@ Object.entries(commands.commands).forEach(([commandName, command]) => {
   } catch (e) {
     console.error(e);
     console.log(command);
-    e.errors.forEach((e) => {
-      console.error(e.message);
-      console.error(`${command.name}.${e.path.join(".")}`);
+    (e.issues ?? [e]).forEach((issue) => {
+      console.error(issue.message);
+      console.error(`${command.name}.${issue.path?.join(".") ?? ""}`);
     });
     console.error(`Command "${commandName}" is invalid.`);
     process.exit(1);
@@ -79,7 +79,7 @@ const findOptionsLength = (options = []) =>
         option.name.length +
         findLongestLocalizationLength(option.description_localizations) +
         (
-          option?.choices?.map((choice) => choice.value.length + choice.name.length) ?? []
+          option?.choices?.map((choice) => String(choice.value).length + choice.name.length) ?? []
         ).reduce((a, b) => a + b, 0)
     )
     .reduce((a, b) => a + b, 0);


### PR DESCRIPTION
## Summary
- Update the command validation script for current Node/Zod behavior so it runs successfully instead of failing on JSON import assertions or Zod v4 schema/error shapes.
- Make maintenance scripts wait for their asynchronous Redis/Mongo work before reporting completion, which makes scheduled/manual runs more reliable and easier to debug.
- Apply historical Redis leaderboard prefixes consistently when trimming leaderboard sizes, avoiding accidental lifetime-key trimming during historical cleanup.
- Correct a small API key deletion confirmation bug and refresh README pnpm workspace examples to match the commands used by the repo.

## Why / Benefits
- Keeps the changes localized to developer and maintenance tooling, avoiding public API or bot command behavior changes.
- Reduces the chance of silent maintenance script failures by replacing fire-and-forget async work with awaited operations.
- Makes Redis limiter behavior match its existing cleanup path, which is safer for historical leaderboard maintenance.
- Improves contributor workflow by making validation and README setup commands accurate.

## Validation
- [x] pnpm --filter scripts lint
- [x] pnpm --filter scripts validate-commands
- [x] git diff --check
- [x] pnpm lint
- [x] pnpm test:types
- [x] pnpm test
- [x] pnpm build