### PR TITLE
build: switch type checking from tsc to tsgo

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node --enable-source-maps .",
     "build": "swc src  --config-file ../../.swcrc --out-dir dist --strip-leading-paths",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsgo --noEmit",
     "lint": "eslint"
   },
   "dependencies": {

--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node --enable-source-maps .",
     "build": "swc src --out-dir dist --strip-leading-paths",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsgo --noEmit",
     "lint": "eslint"
   },
   "dependencies": {

--- a/apps/support-bot/package.json
+++ b/apps/support-bot/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node --enable-source-maps .",
     "build": "swc src --out-dir dist --strip-leading-paths",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsgo --noEmit",
     "lint": "eslint"
   },
   "dependencies": {

--- a/apps/verify-server/package.json
+++ b/apps/verify-server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node --enable-source-maps .",
     "build": "swc src  --config-file ../../.swcrc --out-dir dist --strip-leading-paths",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsgo --noEmit",
     "lint": "eslint"
   },
   "dependencies": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "swc src  --config-file ../../.swcrc --out-dir dist --strip-leading-paths",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsgo --noEmit",
     "lint": "eslint"
   },
   "dependencies": {

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "swc src  --config-file ../../.swcrc --out-dir dist --strip-leading-paths",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsgo --noEmit",
     "lint": "eslint"
   },
   "dependencies": {

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "swc src  --config-file ../../.swcrc --out-dir dist --strip-leading-paths",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsgo --noEmit",
     "lint": "eslint"
   },
   "dependencies": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "swc src  --config-file ../../.swcrc --out-dir dist --strip-leading-paths",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsgo --noEmit",
     "lint": "eslint"
   },
   "dependencies": {

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "swc src  --config-file ../../.swcrc --out-dir dist --strip-leading-paths",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsgo --noEmit",
     "lint": "eslint"
   },
   "dependencies": {

--- a/packages/rendering/package.json
+++ b/packages/rendering/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "build": "swc src --out-dir dist --strip-leading-paths",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsgo --noEmit",
     "lint": "eslint"
   },
   "dependencies": {

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "swc src  --config-file ../../.swcrc --out-dir dist --strip-leading-paths --copy-files",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsgo --noEmit",
     "lint": "eslint"
   },
   "dependencies": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "swc src  --config-file ../../.swcrc --out-dir dist --strip-leading-paths",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsgo --noEmit",
     "lint": "eslint"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Replaces `tsc --noEmit` with `tsgo --noEmit` in the `test:types` script across all 12 packages and apps

## Test plan
- [ ] Run `pnpm test:types` in each package and confirm tsgo type-checks without errors