### PR TITLE
fix: use file urls for dynamic imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || 'origin/main' }}
+      TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
       TURBO_TELEMETRY_DISABLED: 1
     steps:
       - name: Checkout repository
@@ -58,4 +58,4 @@ jobs:
         run: pnpm build --affected
 
       - name: Test
-        run: pnpm test:coverage
+        run: pnpm test:coverage --changed=$TURBO_SCM_BASE

--- a/packages/discord/src/command/command.loader.ts
+++ b/packages/discord/src/command/command.loader.ts
@@ -10,13 +10,15 @@ import { Container } from "typedi";
 import { Logger } from "@statsify/logger";
 import { readdir } from "node:fs/promises";
 import { statSync } from "node:fs";
+import { join } from "node:path";
 import type { CommandResolvable } from "./command.resolvable.js";
 import { scanCommands } from "./command.builder.js";
+import { pathToFileURL } from "node:url";
 
 const logger = new Logger("CommandLoader");
 
 export async function loadCommands(dir: string) {
-  const files = await getCommandFiles(dir);
+  const files = await getCommandFileUrls(dir);
   const commands = await Promise.all(files.map(importCommand));
 
   return new Map<string, CommandResolvable>(
@@ -54,19 +56,19 @@ async function importCommand(file: string) {
     });
 }
 
-async function getCommandFiles(dir: string): Promise<string[]> {
+async function getCommandFileUrls(dir: string): Promise<string[]> {
   const toLoad: string[] = [];
 
   const files = await readdir(dir);
 
   await Promise.all(
     files.map(async (file) => {
-      const path = `${dir}/${file}`;
+      const path = join(dir, file);
 
       if (statSync(path).isDirectory()) {
-        toLoad.push(...(await getCommandFiles(path)));
+        toLoad.push(...(await getCommandFileUrls(path)));
       } else if (file.endsWith(".command.js")) {
-        toLoad.push(path);
+        toLoad.push(pathToFileURL(path).href);
       }
     }),
   );

--- a/packages/discord/src/event/event.loader.ts
+++ b/packages/discord/src/event/event.loader.ts
@@ -13,11 +13,12 @@ import { Logger } from "@statsify/logger";
 import { WebsocketShard } from "tiny-discord";
 import { readdir } from "node:fs/promises";
 import { statSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 
 const logger = new Logger("EventLoader");
 
 export async function loadEvents(websocket: WebsocketShard, dir: string) {
-  const files = await getEventFiles(dir);
+  const files = await getEventFileUrls(dir);
   const events = await Promise.all(files.map(importEvent));
   const eventsMap = new Map<GatewayDispatchEvents, AbstractEventListener<any>>(events.flat().map((event) => [event.event, event]));
 
@@ -48,7 +49,7 @@ async function importEvent(
     .filter(Boolean) as AbstractEventListener<any>[];
 }
 
-async function getEventFiles(dir: string): Promise<string[]> {
+async function getEventFileUrls(dir: string): Promise<string[]> {
   const toLoad: string[] = [];
 
   const files = await readdir(dir);
@@ -58,9 +59,9 @@ async function getEventFiles(dir: string): Promise<string[]> {
       const path = `${dir}/${file}`;
 
       if (statSync(path).isDirectory()) {
-        toLoad.push(...(await getEventFiles(path)));
+        toLoad.push(...(await getEventFileUrls(path)));
       } else if (file.endsWith(".event.js")) {
-        toLoad.push(path);
+        toLoad.push(pathToFileURL(file).href);
       }
     }),
   );

--- a/packages/util/src/config.ts
+++ b/packages/util/src/config.ts
@@ -9,6 +9,7 @@
 import { join } from "node:path";
 import { existsSync } from "node:fs";
 import type { DeepFlatten } from "./flatten.js";
+import { pathToFileURL } from "node:url";
 
 const directory = import.meta.dirname;
 
@@ -280,13 +281,15 @@ async function loadConfig(): Promise<{ default: Config }> {
     };
   }
 
-  if (existsSync(join(directory, "../../../config.json"))) {
-    return import(join(directory, "../../../config.json"));
-  } else if (existsSync(join(directory, "../../../config.js"))) {
-    return import(join(directory, "../../../config.js"));
+  for (const file of ["config.json", "config.js"]) { 
+    const path = join(directory, "../../../", file);
+
+    if (existsSync(path)) {
+      return import(pathToFileURL(path).href);
+    }
   }
-    throw new Error("No config file detected!");
   
+  throw new Error("No config file detected!");
 }
 
 let cfg: Config;


### PR DESCRIPTION
- Instead of absolute paths use file urls for dynamic imports
- This allows the api and discord-bot to be ran on Windows without WSL