### PR TITLE
fix(font-renderer): Add back &r (reset) formatting behavior

### DIFF
--- a/packages/rendering/src/font/font-renderer.ts
+++ b/packages/rendering/src/font/font-renderer.ts
@@ -129,7 +129,7 @@ export class FontRenderer {
 
     if (!text) return [{ ...defaultState, text: "" }];
 
-    let state = defaultState;
+    let state = Object.assign({}, defaultState);
     const parts = (text.startsWith("§") ? text : `§f${text}`).split("§");
 
     const nodes: TextNode[] = [];
@@ -160,7 +160,7 @@ export class FontRenderer {
 
       if (matches) text = text.slice(matches[0].length);
 
-      Object.assign(state, effect);
+      state = Object.assign({}, state, effect);
 
       if (text.length === 0) continue;
 

--- a/packages/rendering/tests/index.spec.tsx
+++ b/packages/rendering/tests/index.spec.tsx
@@ -6,7 +6,7 @@
  * https://github.com/Statsify/statsify/blob/main/LICENSE
  */
 
-import { createInstructions } from "../src/index.js";
+import { FontRenderer, createInstructions } from "../src/index.js";
 import { expect, it, suite } from "vitest";
 
 suite("createInstructions with no relative sizes", () => {
@@ -154,5 +154,17 @@ suite("JSX Fragments", () => {
     );
 
     expect(instructions.children?.length).toBe(2);
+  });
+});
+
+suite("FontRenderer", () => {
+  it("resets formatting without inheriting mutated parser state", () => {
+    const renderer = new FontRenderer(false);
+    const nodes = renderer.lex("§l[100]§r Player");
+
+    expect(nodes).toEqual([
+      expect.objectContaining({ text: "[100]", bold: true }),
+      expect.objectContaining({ text: " Player", bold: false }),
+    ]);
   });
 });


### PR DESCRIPTION
Fixes bold leaderboards, and the &r reset colorcode functionality, also includes a test for FontRenderer lex method to ensure formatting resets correctly