### PR TITLE
fix(i18n-loader): only load language files/folders

### DIFF
--- a/packages/discord/src/services/i18n-loader.service.ts
+++ b/packages/discord/src/services/i18n-loader.service.ts
@@ -20,10 +20,18 @@ export class I18nLoaderService {
   private namespaces: string[] = [];
 
   public async init() {
-    this.languages = await readdir("../../locales");
-    this.namespaces = (await readdir(`../../locales/${DEFAULT_LANGUAGE}/`)).map((p) =>
-      p.replace(".json", "")
-    );
+    const languageEntries = await readdir("../../locales", { withFileTypes: true });
+    this.languages = languageEntries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+
+    const namespaceEntries = await readdir(`../../locales/${DEFAULT_LANGUAGE}/`, {
+      withFileTypes: true,
+    });
+
+    this.namespaces = namespaceEntries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .map((entry) => entry.name.replace(".json", ""));
 
     await i18next.use(Backend).init({
       backend: {


### PR DESCRIPTION
Only read/keep the files that are languages (so ds_store doesn't leak into command localizations)

Description:
Related issues (if exists):