### PR TITLE
fix(bedwars): make light color scheme use white

### DIFF
--- a/packages/schemas/src/player/gamemodes/bedwars/util.ts
+++ b/packages/schemas/src/player/gamemodes/bedwars/util.ts
@@ -148,7 +148,7 @@ export const SCHEME_MAP = {
   opal_prime: createUniformScheme("§7", "§9", "§1"),
   amethyst_prime: createUniformScheme("§7", "§5", "§8"),
   mirror: createCycleScheme("§8", "§7", "§f", "§f", "§7", "§7"),
-  light: createCycleScheme("§7", "§7", "§e", "§e", "§6", "§6", "§6"),
+  light: createCycleScheme("§f", "§f", "§e", "§e", "§6", "§6", "§6"),
   dawn: createCycleScheme("§6", "§6", "§f", "§f", "§b", "§3", "§3"),
   dusk: createCycleScheme("§5", "§5", "§d", "§d", "§6", "§e", "§e"),
   air: createCycleScheme("§b", "§b", "§f", "§f", "§7", "§7", "§8", "§8"),


### PR DESCRIPTION
Light prestige should use white, rather than the old gray color code.

<img width="362" height="844" alt="image" src="https://github.com/user-attachments/assets/bbca61d0-af5a-4514-a3df-d22a418741fc" />

<img width="600" height="349" alt="image" src="https://github.com/user-attachments/assets/51938ef1-6645-4251-bb8b-ef7aca2f239e" />